### PR TITLE
merged development branch into master

### DIFF
--- a/ArticyImporter/ArticyImporter.uplugin
+++ b/ArticyImporter/ArticyImporter.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.0.2",
+	"VersionName": "0.0.3",
 	"FriendlyName": "ArticyImporter",
 	"Description": "Importer and interface for articy:draft.",
 	"Category": "Articy",

--- a/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
+++ b/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
@@ -9,7 +9,7 @@ public class ArticyImporter : ModuleRules
 	public ArticyImporter(ReadOnlyTargetRules Target) : base(Target)
 	{
 
-		//OptimizeCode = CodeOptimization.Never;
+		OptimizeCode = CodeOptimization.Never;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
+++ b/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
@@ -10,7 +10,7 @@ public class ArticyImporter : ModuleRules
 	public ArticyImporter(ReadOnlyTargetRules Target) : base(Target)
 	{
 
-		OptimizeCode = CodeOptimization.Never;
+		//OptimizeCode = CodeOptimization.Never;
 
 		PublicIncludePaths.AddRange(
 			new string[] {
@@ -22,7 +22,6 @@ public class ArticyImporter : ModuleRules
 #else
 				"GameProjectGeneration",
 #endif
-
 			}
 			);
 

--- a/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
+++ b/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
@@ -8,7 +8,9 @@ public class ArticyImporter : ModuleRules
 {
 	public ArticyImporter(ReadOnlyTargetRules Target) : base(Target)
 	{
-		
+
+		//OptimizeCode = CodeOptimization.Never;
+
 		PublicIncludePaths.AddRange(
 			new string[] {
 				"ArticyImporter/Public",

--- a/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
+++ b/ArticyImporter/Source/ArticyImporter/ArticyImporter.Build.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.  
 //
 using UnrealBuildTool;
+using System.IO;
 
 public class ArticyImporter : ModuleRules
 {
@@ -13,22 +14,26 @@ public class ArticyImporter : ModuleRules
 
 		PublicIncludePaths.AddRange(
 			new string[] {
-				"ArticyImporter/Public",
+				Path.Combine(ModuleDirectory, "Public"),
+				Path.Combine(ModuleDirectory, "../ArticyImporter/Public"),
 				// ... add public include paths required here ...
-                "GameProjectGeneration",
-                "ArticyRuntime/Public"
+#if UE_4_20_OR_LATER
+				Path.Combine(EngineDirectory, "Source/Editor/GameProjectGeneration"),
+#else
+				"GameProjectGeneration",
+#endif
+
 			}
 			);
-				
-		
+
+
 		PrivateIncludePaths.AddRange(
 			new string[] {
-				"ArticyImporter/Private",
+				Path.Combine(ModuleDirectory, "Private"),
 				// ... add other private include paths required here ...
 			}
 			);
-			
-		
+
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
@@ -293,10 +293,8 @@ void FAIDUserMethods::ImportFromJson(const TArray<TSharedPtr<FJsonValue>>* Json)
 	}
 
 	// mark overloaded methods
-	for (auto scriptMethod : ScriptMethods)
-	{
+	for (auto& scriptMethod : ScriptMethods)
 		scriptMethod.bIsOverloadedFunction = OverloadedMethods.Contains(scriptMethod.Name);
-	}
 }
 
 //---------------------------------------------------------------------------//

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
@@ -505,7 +505,7 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 					for (int i = 0; i < valueStr.Len(); i++)
 					{
 						auto currentChar = valueStr[i];
-						if (currentChar == ' ' || currentChar == '<' || currentChar == '>' || currentChar == '=')
+						if (currentChar == ' ' || currentChar == '<' || currentChar == '>' || currentChar == '=' || currentChar == '+' || currentChar == '-')
 							continue;
 						else if (currentChar == '\"' && i > 0)
 							valueStr.InsertAt(i, "(FString)");

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
@@ -431,7 +431,7 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 	//match any group of two words separated by a dot, that does not start with a double quote
 	// (?<!["a-zA-Z])(\w+\.\w+)
 	//NOTE: static is no good here! crashes on application quit...
-	const FRegexPattern unquotedWordDotWord(TEXT("(?<![\"a-zA-Z])([a-zA-Z]+\\.[a-zA-Z]+)"));
+	const FRegexPattern unquotedWordDotWord(TEXT("(?<![\"a-zA-Z_])([a-zA-Z_]{1}\\w+\\.\\w+)"));
 	//match an assignment operator (an = sign that does not have any of [ = < > ] before it, and no = after it)
 	const FRegexPattern assignmentOperator(TEXT("(?<![=<>])=(?!=)"));
 

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImportData.cpp
@@ -514,8 +514,8 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 					}
 					
 					//get the dereferenced variable
-					line = line.Left(start) + "*" + line.Mid(start, end - start).Replace(TEXT("."), TEXT("->")) + valueStr;
-					offset += strlen(".") + strlen(">");
+					line = line.Left(start) + "(*" + line.Mid(start, end - start).Replace(TEXT("."), TEXT("->")) + ")" + valueStr;
+					offset += strlen(".") + strlen(">") + strlen("()");
 				}
 			}
 

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImporter.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImporter.cpp
@@ -4,111 +4,55 @@
 //
 #include "ArticyImporterPrivatePCH.h"
 
-#include "SlateBasics.h"
-#include "SlateExtras.h"
+#include "ArticyPluginSettings.h"
+#include "ArticyPluginSettingsCustomization.h"
 
-#include "ArticyImporterStyle.h"
-#include "ArticyImporterCommands.h"
-
-#include "LevelEditor.h"
-
-#include "ArticyGlobalVariables.h"
-#include "ArticyBaseTypes.h"
-#include "ArticyHelpers.h"
-#include "ArticyRef.h"
+#include "Developer/Settings/Public/ISettingsModule.h"
+#include "Developer/Settings/Public/ISettingsSection.h"
+#include "Developer/Settings/Public/ISettingsContainer.h"
+#include "Editor/PropertyEditor/Public/PropertyEditorModule.h"
 
 DEFINE_LOG_CATEGORY(LogArticyImporter)
-
-static const FName ArticyImporterTabName("ArticyImporter");
 
 #define LOCTEXT_NAMESPACE "FArticyImporterModule"
 
 void FArticyImporterModule::StartupModule()
 {
-	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
-	/*
-	FArticyImporterStyle::Initialize();
-	FArticyImporterStyle::ReloadTextures();
-
-	FArticyImporterCommands::Register();
-	
-	PluginCommands = MakeShareable(new FUICommandList);
-
-	PluginCommands->MapAction(
-		FArticyImporterCommands::Get().OpenPluginWindow,
-		FExecuteAction::CreateRaw(this, &FArticyImporterModule::PluginButtonClicked),
-		FCanExecuteAction());
-		
-	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-	
-	{
-		TSharedPtr<FExtender> MenuExtender = MakeShareable(new FExtender());
-		MenuExtender->AddMenuExtension("WindowLayout", EExtensionHook::After, PluginCommands, FMenuExtensionDelegate::CreateRaw(this, &FArticyImporterModule::AddMenuExtension));
-
-		LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(MenuExtender);
-	}
-	
-	{
-		TSharedPtr<FExtender> ToolbarExtender = MakeShareable(new FExtender);
-		ToolbarExtender->AddToolBarExtension("Settings", EExtensionHook::After, PluginCommands, FToolBarExtensionDelegate::CreateRaw(this, &FArticyImporterModule::AddToolbarExtension));
-		
-		LevelEditorModule.GetToolBarExtensibilityManager()->AddExtender(ToolbarExtender);
-	}
-	
-	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(ArticyImporterTabName, FOnSpawnTab::CreateRaw(this, &FArticyImporterModule::OnSpawnPluginTab))
-		.SetDisplayName(LOCTEXT("FArticyImporterTabTitle", "ArticyImporter"))
-		.SetMenuType(ETabSpawnerMenuType::Hidden);
-	*/
+	RegisterPluginSettings();
 }
 
 void FArticyImporterModule::ShutdownModule()
 {
-	/*
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
-	FArticyImporterStyle::Shutdown();
-
-	FArticyImporterCommands::Unregister();
-
-	FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(ArticyImporterTabName);*/
+	if (UObjectInitialized())
+	{
+		UnregisterPluginSettings();
+	}
 }
-/*
-TSharedRef<SDockTab> FArticyImporterModule::OnSpawnPluginTab(const FSpawnTabArgs& SpawnTabArgs)
+
+void FArticyImporterModule::RegisterPluginSettings()
 {
-	FText WidgetText = FText::Format(
-		LOCTEXT("WindowWidgetText", "Add code to {0} in {1} to override this window's contents"),
-		FText::FromString(TEXT("FArticyImporterModule::OnSpawnPluginTab")),
-		FText::FromString(TEXT("ArticyImporter.cpp"))
+	ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
+
+	if (SettingsModule != nullptr)
+	{
+		ISettingsSectionPtr SettingsSectionPtr = SettingsModule->RegisterSettings("Project", "Plugins", "ArticyImporter",
+			LOCTEXT("Name", "Articy Importer"),
+			LOCTEXT("Description", "Articy Importer Configuration."),
+			GetMutableDefault<UArticyPluginSettings>()
 		);
+	}
 
-	return SNew(SDockTab)
-		.TabRole(ETabRole::NomadTab)
-		[
-			// Put your tab content here!
-			SNew(SBox)
-			.HAlign(HAlign_Center)
-			.VAlign(VAlign_Center)
-			[
-				SNew(STextBlock)
-				.Text(WidgetText)
-			]
-		];
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomClassLayout("ArticyPluginSettings", FOnGetDetailCustomizationInstance::CreateStatic(&FArticyPluginSettingsCustomization::MakeInstance));
 }
 
-void FArticyImporterModule::PluginButtonClicked()
+void FArticyImporterModule::UnregisterPluginSettings()
 {
-	FGlobalTabmanager::Get()->InvokeTab(ArticyImporterTabName);
+	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+	{
+		SettingsModule->UnregisterSettings("Project", "Plugins", "ArticyImporter");
+	}
 }
-
-void FArticyImporterModule::AddMenuExtension(FMenuBuilder& Builder)
-{
-	Builder.AddMenuEntry(FArticyImporterCommands::Get().OpenPluginWindow);
-}
-
-void FArticyImporterModule::AddToolbarExtension(FToolBarBuilder& Builder)
-{
-	Builder.AddToolBarButton(FArticyImporterCommands::Get().OpenPluginWindow);
-}*/
 
 #undef LOCTEXT_NAMESPACE
 	

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyImporterFunctionLibrary.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyImporterFunctionLibrary.cpp
@@ -1,0 +1,61 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "ArticyImporterPrivatePCH.h"
+#include "ArticyImporter.h"
+#include "ArticyImporterFunctionLibrary.h"
+#include "ArticyJSONFactory.h"
+#include "CodeGeneration/CodeGenerator.h"
+
+void FArticyImporterFunctionLibrary::ForceCompleteReimport(UArticyImportData* ImportData)
+{
+	if (!EnsureImportFile(&ImportData))
+		return;
+
+	ImportData->Settings.ObjectDefinitionsHash.Reset();
+	ReimportChanges(ImportData);
+}
+
+void FArticyImporterFunctionLibrary::ReimportChanges(UArticyImportData* ImportData)
+{
+	if (!EnsureImportFile(&ImportData))
+		return;
+
+	const auto factory = NewObject<UArticyJSONFactory>();
+	if (factory)
+	{
+		factory->Reimport(ImportData);
+		//GC will destroy factory
+	}
+}
+
+void FArticyImporterFunctionLibrary::RegenerateAssets(UArticyImportData* ImportData)
+{
+	if (!EnsureImportFile(&ImportData))
+		return;
+
+	CodeGenerator::Recompile(ImportData);
+}
+
+bool FArticyImporterFunctionLibrary::EnsureImportFile(UArticyImportData** ImportData)
+{
+	if (!*ImportData)
+	{
+		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		TArray<FAssetData> AssetData;
+		AssetRegistryModule.Get().GetAssetsByClass(UArticyImportData::StaticClass()->GetFName(), AssetData);
+
+		if (!AssetData.Num())
+		{
+			UE_LOG(LogArticyImporter, Error, TEXT("Could not found an import file."));
+		}
+		else
+		{
+			*ImportData = Cast<UArticyImportData>(AssetData[0].GetAsset());
+
+			if (AssetData.Num() > 1)
+				UE_LOG(LogArticyImporter, Error, TEXT("Found more than one import file. This is not supported by the plugin. Using the first found file for now: %s"), *AssetData[0].ObjectPath.ToString());
+		}
+	}
+
+	return *ImportData;
+}

--- a/ArticyImporter/Source/ArticyImporter/Private/ArticyPluginSettingsCustomization.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ArticyPluginSettingsCustomization.cpp
@@ -1,0 +1,65 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "ArticyImporterPrivatePCH.h"
+#include "ArticyPluginSettingsCustomization.h"
+
+#include "ArticyImporterFunctionLibrary.h"
+#include "DetailLayoutBuilder.h"
+#include "DetailWidgetRow.h"
+#include "DetailCategoryBuilder.h"
+
+#define LOCTEXT_NAMESPACE "ArticyPluginSettings"
+
+FArticyPluginSettingsCustomization::FArticyPluginSettingsCustomization()
+{
+
+}
+
+TSharedRef<IDetailCustomization> FArticyPluginSettingsCustomization::MakeInstance()
+{
+	return MakeShareable(new FArticyPluginSettingsCustomization);
+}
+
+void FArticyPluginSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailLayout)
+{
+	IDetailCategoryBuilder& ImportActionsCategory = DetailLayout.EditCategory("ImportActions");
+
+	ImportActionsCategory.AddCustomRow(LOCTEXT("ForceCompleteReimport_Row", ""))
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("ForceCompleteReimport", "Force complete reimport"))
+				.ToolTipText(LOCTEXT("ForceCompleteReimport_Tooltip", "Performs a complete reimport and asset regeneration."))
+				.OnClicked_Lambda([]()->FReply { FArticyImporterFunctionLibrary::ForceCompleteReimport(); return FReply::Handled(); })
+			]
+		];
+
+	ImportActionsCategory.AddCustomRow(LOCTEXT("ReimportChanges_Row", ""))
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("ReimportChanges", "Reimport changes"))
+			.ToolTipText(LOCTEXT("ReimportChanges_Tooltip", "Reimports data from the json file and regenerates assets. Does not reimport GVs and ObjectDefinitions if the hash is still the same."))
+			.OnClicked_Lambda([]()->FReply { FArticyImporterFunctionLibrary::ReimportChanges(); return FReply::Handled(); })
+			]
+		];
+
+	ImportActionsCategory.AddCustomRow(LOCTEXT("RegenerateAssets_Row", ""))
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("RegenerateAssets", "Regenerate Assets"))
+				.ToolTipText(LOCTEXT("RegenerateAssets_Tooltip", "Clears and regenerates all assets, but no code."))
+				.OnClicked_Lambda([]()->FReply { FArticyImporterFunctionLibrary::RegenerateAssets(); return FReply::Handled(); })
+			]
+		];
+}

--- a/ArticyImporter/Source/ArticyImporter/Private/CodeFileGenerator.h
+++ b/ArticyImporter/Source/ArticyImporter/Private/CodeFileGenerator.h
@@ -133,7 +133,7 @@ CodeFileGenerator::CodeFileGenerator(const FString& Path, const bool bHeader, La
 
 	Line();
 
-	if(ensure(!std::is_null_pointer_v<Lambda>))
+	if(ensure(!std::is_null_pointer<Lambda>::value))
 		ContentGenerator(this);
 
 	WriteToFile();
@@ -229,7 +229,7 @@ void CodeFileGenerator::Method(const FString& ReturnType, const FString& Name, c
 		this->UFunctionMacro(UFunctionSpecifiers);
 
 	//check if nullptr was passed as Definition
-	constexpr auto hasDefinition = !std::is_null_pointer_v<Lambda>;
+	constexpr auto hasDefinition = !std::is_null_pointer<Lambda>::value;
 
 	//ReturnType Name(Parameters..)
 	//only add the semicolon if there is no definition

--- a/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/CodeGenerator.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/CodeGenerator.cpp
@@ -21,7 +21,7 @@
 
 FString CodeGenerator::GetSourceFolder()
 {
-	return FPaths::GameSourceDir() / FApp::GetGameName() / TEXT("ArticyGenerated");
+	return FPaths::GameSourceDir() / FApp::GetProjectName() / TEXT("ArticyGenerated");
 }
 
 FString CodeGenerator::GetGeneratedTypesFilename(const UArticyImportData* Data)
@@ -150,7 +150,7 @@ void CodeGenerator::OnCompiled(const ECompilationResult::Type Result, UArticyImp
 	//compiling is done!
 	//check if UArticyBaseGlobalVariables can be found, otherwise something went wrong!
 	auto className = GetGlobalVarsClassname(Data, true);
-	auto fullClassName = FString::Printf(TEXT("Class'/Script/%s.%s'"), FApp::GetGameName(), *className);
+	auto fullClassName = FString::Printf(TEXT("Class'/Script/%s.%s'"), FApp::GetProjectName(), *className);
 	if(!ensure(ConstructorHelpersInternal::FindOrLoadClass(fullClassName, UArticyGlobalVariables::StaticClass())))
 		UE_LOG(LogArticyImporter, Error, TEXT("Could not find generated global variables class after compile!"));
 

--- a/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/DatabaseGenerator.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/DatabaseGenerator.cpp
@@ -60,5 +60,5 @@ void DatabaseGenerator::GenerateCode(const UArticyImportData* Data)
 UArticyDatabase* DatabaseGenerator::GenerateAsset(const UArticyImportData* Data)
 {
 	const auto className = CodeGenerator::GetDatabaseClassname(Data, true);
-	return ArticyHelpers::GenerateAsset<UArticyDatabase>(*className, FApp::GetGameName());
+	return ArticyHelpers::GenerateAsset<UArticyDatabase>(*className, FApp::GetProjectName());
 }

--- a/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/GlobalVarsGenerator.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/GlobalVarsGenerator.cpp
@@ -43,7 +43,6 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 					//create subobject
 					for(const auto var : ns.Variables)
 						header->Line(FString::Printf(TEXT("%s = CreateDefaultSubobject<%s>(\"%s\");"), *var.Variable, *var.GetCPPTypeString(), *var.Variable));
-
 				});
 
 				header->Line();
@@ -54,7 +53,10 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 					header->Comment("initialize the variables");
 
 					for(const auto var : ns.Variables)
+					{
 						header->Line(FString::Printf(TEXT("%s->Init<%s>(this, Store, TEXT(\"%s.%s\"), %s);"), *var.Variable, *var.GetCPPTypeString(), *ns.Namespace, *var.Variable, *var.GetCPPValueString()));
+						header->Line(FString::Printf(TEXT("this->Variables.Add(%s);"), *var.Variable));
+					}					
 				});
 			});
 		}
@@ -81,9 +83,7 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 			{
 				header->Comment("create the namespaces");
 				for(const auto ns : Data->GetGlobalVars().Namespaces)
-				{
 					header->Line(FString::Printf(TEXT("%s = CreateDefaultSubobject<%s>(\"%s\");"), *ns.Namespace, *ns.CppTypename, *ns.Namespace));
-				}
 
 				header->Line();
 				header->Line("Init();");
@@ -98,6 +98,7 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 				for(const auto ns : Data->GetGlobalVars().Namespaces)
 				{
 					header->Line(FString::Printf(TEXT("%s->Init(this);"), *ns.Namespace));
+					header->Line(FString::Printf(TEXT("this->VariableSets.Add(%s);"), *ns.Namespace));
 				}
 			});
 
@@ -116,5 +117,5 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 void GlobalVarsGenerator::GenerateAsset(const UArticyImportData* Data)
 {
 	const auto className = CodeGenerator::GetGlobalVarsClassname(Data, true);
-	ArticyHelpers::GenerateAsset<UArticyGlobalVariables>(*className, FApp::GetGameName());
+	ArticyHelpers::GenerateAsset<UArticyGlobalVariables>(*className, FApp::GetProjectName());
 }

--- a/ArticyImporter/Source/ArticyImporter/Private/ExpressoScriptsGenerator.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ExpressoScriptsGenerator.cpp
@@ -103,10 +103,12 @@ void GenerateExpressoScripts(CodeFileGenerator* header, const UArticyImportData*
 		});
 	}, "", false, "", "const override");
 
+	auto methodsProviderClassname = CodeGenerator::GetMethodsProviderClassname(Data);
+
 	header->Line();
 	header->Method("UClass*", "GetUserMethodsProviderInterface", "", [&]
 	{
-		header->Line(FString::Printf(TEXT("return %s::StaticClass();"), *CodeGenerator::GetMethodsProviderClassname(Data)));
+		header->Line(FString::Printf(TEXT("return %s::StaticClass();"), *methodsProviderClassname));
 	}, "", false, "", "override");
 
 	header->Line();

--- a/ArticyImporter/Source/ArticyImporter/Private/ObjectDefinitionsImport.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ObjectDefinitionsImport.cpp
@@ -507,7 +507,7 @@ UClass* FArticyTemplateFeatureDef::GetUClass(const UArticyImportData* Data) cons
 	//remove the 'U' at the beginning of the class name, since FindOrLoadClass doesn't like that one....
 	className.RemoveAt(0);
 
-	auto fullClassName = FString::Printf(TEXT("Class'/Script/%s.%s'"), FApp::GetGameName(), *className);
+	auto fullClassName = FString::Printf(TEXT("Class'/Script/%s.%s'"), FApp::GetProjectName(), *className);
 	return ConstructorHelpersInternal::FindOrLoadClass(fullClassName, UObject::StaticClass());
 }
 
@@ -619,6 +619,7 @@ const FName& FArticyObjectDefinitions::GetProviderInterface(const FArticyPropert
 		ProviderInterfaces.Add(OBJECT_WITH_X("StageDirections"));
 		ProviderInterfaces.Add(OBJECT_WITH_X("Target"));
 		ProviderInterfaces.Add(OBJECT_WITH_X("Text"));
+		ProviderInterfaces.Add(OBJECT_WITH_X("Transform"));
 		ProviderInterfaces.Add(OBJECT_WITH_X("Vertices"));
 		ProviderInterfaces.Add(OBJECT_WITH_X("ZIndex"));
 	}

--- a/ArticyImporter/Source/ArticyImporter/Private/ObjectDefinitionsImport.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/ObjectDefinitionsImport.cpp
@@ -284,7 +284,7 @@ void FArticyPropertyDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonProper
 			});
 
 			if(ensure(constraint)) //the constraint should exist
-				bIsLocalized = constraint->IsLocalized && ensure(Type == string);
+				bIsLocalized = constraint->IsLocalized && Type == string;
 		}
 		else if(Type == string)
 		{

--- a/ArticyImporter/Source/ArticyImporter/Private/PackagesImport.h
+++ b/ArticyImporter/Source/ArticyImporter/Private/PackagesImport.h
@@ -26,6 +26,8 @@ public:
 	FName GetType() const { return Type; }
 	const FString& GetTechnicalName() const { return TechnicalName; }
 	const FString& GetNameAndId() const { return NameAndId; }
+	const FArticyId& GetId() const { return Id; }
+	const FArticyId& GetParent() const { return Parent; }
 
 	const FString& GetAssetRef() const { return AssetRef; }
 	const EArticyAssetCategory& GetAssetCat() const { return Category; }
@@ -33,6 +35,8 @@ public:
 	TSharedPtr<FJsonObject> GetTemplatesJson() const;
 
 private:
+
+	EArticyAssetCategory GetAssetCategoryFromString(const FString AssetCategory);
 
 	/** The original type of the model as read in from json. */
 	UPROPERTY(VisibleAnywhere, Category = "Model")
@@ -78,7 +82,7 @@ public:
 
 	void ImportFromJson(const TSharedPtr<FJsonObject> JsonPackage);
 	void GatherScripts(UArticyImportData* Data) const;
-	FArticyPackage GenerateAssets(const UArticyImportData* Data) const;
+	FArticyPackage GenerateAssets(UArticyImportData* Data) const;
 
 	FString GetFolder() const;
 

--- a/ArticyImporter/Source/ArticyImporter/Private/PredefinedTypes.h
+++ b/ArticyImporter/Source/ArticyImporter/Private/PredefinedTypes.h
@@ -18,7 +18,7 @@ class UArticyImportData;
 //same as PREDEFINED_TYPE, but with a custom DefaultValue and Deserializer.
 #define PREDEFINE_TYPE_EXT(Type, DefaultValue, Deserializer) new ArticyPredefinedTypeInfo<Type>(#Type, #Type, DefaultValue, Deserializer)
 //same as PREDEFINED_TYPE_EX, but creates a ArticyObjectTypeInfo, which has a default deserializer
-#define PREDEFINE_ARTICYOBJECT_TYPE(Type) new ArticyObjectTypeInfo<Type, Type##*>(#Type, #Type"*")
+#define PREDEFINE_ARTICYOBJECT_TYPE(Type) new ArticyObjectTypeInfo<Type, Type*>(#Type, #Type"*")
 
 #define PROP_SETTER_PARAMS UArticyBaseObject* Model, const FString& Path, const TSharedPtr<FJsonValue> Json
 #define ARRAY_SETTER_PARAMS UArticyBaseObject* Model, const FString& Path, const TArray<TSharedPtr<FJsonValue>> JsonArray

--- a/ArticyImporter/Source/ArticyImporter/Public/ArticyImporter.h
+++ b/ArticyImporter/Source/ArticyImporter/Public/ArticyImporter.h
@@ -20,16 +20,8 @@ public:
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
-	
-	/** This function will be bound to Command (by default it will bring up plugin window) */
-	//void PluginButtonClicked();
-	
-private:
-	//void AddToolbarExtension(FToolBarBuilder& Builder);
-	//void AddMenuExtension(FMenuBuilder& Builder);
 
-	//TSharedRef<class SDockTab> OnSpawnPluginTab(const class FSpawnTabArgs& SpawnTabArgs);
-
-private:
-	//TSharedPtr<class FUICommandList> PluginCommands;
+	/* Plugin settings menu */
+	void RegisterPluginSettings();
+	void UnregisterPluginSettings();
 };

--- a/ArticyImporter/Source/ArticyImporter/Public/ArticyImporterCommands.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Public/ArticyImporterCommands.cpp
@@ -5,11 +5,11 @@
 #include "ArticyImporterPrivatePCH.h"
 #include "ArticyImporterCommands.h"
 
-#define LOCTEXT_NAMESPACE "FArticyImporterModule"
+//#define LOCTEXT_NAMESPACE "FArticyImporterModule"
 
 void FArticyImporterCommands::RegisterCommands()
 {
 	UI_COMMAND(OpenPluginWindow, "ArticyImporter", "Bring up ArticyImporter window", EUserInterfaceActionType::Button, FInputGesture());
 }
 
-#undef LOCTEXT_NAMESPACE
+//#undef LOCTEXT_NAMESPACE

--- a/ArticyImporter/Source/ArticyImporter/Public/ArticyImporterFunctionLibrary.h
+++ b/ArticyImporter/Source/ArticyImporter/Public/ArticyImporterFunctionLibrary.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+#include "ArticyImportData.h"
+
+/**
+ * 
+ */
+class ARTICYIMPORTER_API FArticyImporterFunctionLibrary
+{
+
+public:
+	static void ForceCompleteReimport(UArticyImportData* = nullptr);
+	static void ReimportChanges(UArticyImportData* = nullptr);
+	static void RegenerateAssets(UArticyImportData* = nullptr);
+	static bool EnsureImportFile(UArticyImportData**);
+};

--- a/ArticyImporter/Source/ArticyImporter/Public/ArticyPluginSettingsCustomization.h
+++ b/ArticyImporter/Source/ArticyImporter/Public/ArticyPluginSettingsCustomization.h
@@ -1,0 +1,16 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "ArticyImporterPrivatePCH.h"
+#include "IDetailCustomization.h"
+
+class FArticyPluginSettingsCustomization : public IDetailCustomization
+{
+public:
+	FArticyPluginSettingsCustomization();
+
+	static TSharedRef<IDetailCustomization> MakeInstance();
+
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailLayout) override;
+};

--- a/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
+++ b/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
@@ -8,7 +8,9 @@ public class ArticyRuntime : ModuleRules
 {
 	public ArticyRuntime(ReadOnlyTargetRules Target) : base(Target)
     {
-		
+
+		//OptimizeCode = CodeOptimization.Never;
+
 		PublicIncludePaths.AddRange(
 			new string[] {
 				"ArticyRuntime/Public",
@@ -46,7 +48,7 @@ public class ArticyRuntime : ModuleRules
 				"Slate",
 				"SlateCore",
 				// ... add private dependencies that you statically link with here ...	
-				"Json"
+				"Json",
 			}
 			);
 		

--- a/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
+++ b/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
@@ -3,32 +3,35 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.  
 //
 using UnrealBuildTool;
+using System.IO;
 
 public class ArticyRuntime : ModuleRules
 {
 	public ArticyRuntime(ReadOnlyTargetRules Target) : base(Target)
     {
-
 		OptimizeCode = CodeOptimization.Never;
+
 
 		PublicIncludePaths.AddRange(
 			new string[] {
-				"ArticyRuntime/Public",
+				Path.Combine(ModuleDirectory, "Public"),
 				// ... add public include paths required here ...
+#if UE_4_20_OR_LATER
+				Path.Combine(EngineDirectory, "Source/Runtime/MediaAssets/Public"),
+#else
 				"MediaAssets/Public",
+#endif
 			}
 			);
-				
-		
+
 		PrivateIncludePaths.AddRange(
 			new string[] {
-				"ArticyRuntime/Private",
+				Path.Combine(ModuleDirectory, "Private"),
 				// ... add other private include paths required here ...
 			}
 			);
-			
-		
-		PublicDependencyModuleNames.AddRange(
+
+			PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
 				"Core",

--- a/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
+++ b/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
@@ -9,8 +9,7 @@ public class ArticyRuntime : ModuleRules
 {
 	public ArticyRuntime(ReadOnlyTargetRules Target) : base(Target)
     {
-		OptimizeCode = CodeOptimization.Never;
-
+		//OptimizeCode = CodeOptimization.Never;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
+++ b/ArticyImporter/Source/ArticyRuntime/ArticyRuntime.Build.cs
@@ -9,7 +9,7 @@ public class ArticyRuntime : ModuleRules
 	public ArticyRuntime(ReadOnlyTargetRules Target) : base(Target)
     {
 
-		//OptimizeCode = CodeOptimization.Never;
+		OptimizeCode = CodeOptimization.Never;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyAsset.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyAsset.cpp
@@ -12,6 +12,11 @@ UTexture* UArticyAsset::LoadAsTexture() const
 	return Cast<UTexture>(GetAsset());
 }
 
+UTexture2D* UArticyAsset::LoadAsTexture2D() const
+{
+	return Cast<UTexture2D>(GetAsset());
+}
+
 UFileMediaSource* UArticyAsset::LoadAsAudio() const
 {
 	return Cast<UFileMediaSource>(GetAsset());
@@ -37,7 +42,7 @@ UObject* UArticyAsset::GetAsset() const
 		const auto filename = FPaths::GetBaseFilename(AssetRef); //without extension
 
 		//construct the asset path like UE4 wants it
-		auto path = ArticyHelpers::ArticyAssetsFolder / folder / filename + "." + filename;
+		auto path = ArticyHelpers::ArticyAssetsFolder / folder / filename;
 		//UE_LOG(LogTemp, Warning, TEXT("Asset Path %s"), *path)
 		Asset = ConstructorHelpersInternal::FindOrLoadObject<UObject>(path);
 	}

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyDatabase.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyDatabase.cpp
@@ -310,7 +310,7 @@ const UArticyDatabase* UArticyDatabase::GetOriginal(bool bLoadAllPackages)
 
 //---------------------------------------------------------------------------//
 
-UArticyPrimitive* UArticyDatabase::GetObject(FArticyId Id, int32 CloneId) const
+UArticyPrimitive* UArticyDatabase::GetObject(FArticyId Id, int32 CloneId, TSubclassOf<class UArticyObject> CastTo) const
 {
 	return GetObjectInternal(Id, CloneId);
 }
@@ -326,7 +326,7 @@ UArticyPrimitive* UArticyDatabase::GetObjectInternal(FArticyId Id, int32 CloneId
 	return info && info->IsValid() ? info->Get()->Get(this, CloneId, bForceUnshadowed) : nullptr;
 }
 
-UArticyObject* UArticyDatabase::GetObjectByName(FName TechnicalName, int32 CloneId) const
+UArticyObject* UArticyDatabase::GetObjectByName(FName TechnicalName, int32 CloneId, TSubclassOf<class UArticyObject> CastTo) const
 {
 	auto arr = LoadedObjectsByName.Find(TechnicalName);
 	if(!arr || arr->Objects.Num() <= 0)
@@ -336,12 +336,12 @@ UArticyObject* UArticyDatabase::GetObjectByName(FName TechnicalName, int32 Clone
 	return info.IsValid() ? Cast<UArticyObject>(info.Pin()->Get(this, CloneId)) : nullptr;
 }
 
-TArray<UArticyObject*> UArticyDatabase::GetObjects(FName TechnicalName, int32 CloneId) const
+TArray<UArticyObject*> UArticyDatabase::GetObjects(FName TechnicalName, int32 CloneId, TSubclassOf<class UArticyObject> CastTo) const
 {
 	return GetObjects<UArticyObject>(TechnicalName, CloneId);
 }
 
-TArray<UArticyObject*> UArticyDatabase::GetObjectsByType(TSubclassOf<class UArticyObject> Type, int32 CloneId) const
+TArray<UArticyObject*> UArticyDatabase::GetObjectsOfClass(TSubclassOf<class UArticyObject> Type, int32 CloneId) const
 {
 	TArray<UArticyObject*> arr;
 	for (auto obj : ArticyObjects)
@@ -358,13 +358,13 @@ TArray<UArticyPrimitive*> UArticyDatabase::GetAllObjects() const
 
 //---------------------------------------------------------------------------//
 
-UArticyPrimitive* UArticyDatabase::CloneFrom(FArticyId Id, int32 NewCloneId)
+UArticyPrimitive* UArticyDatabase::CloneFrom(FArticyId Id, int32 NewCloneId, TSubclassOf<class UArticyObject> CastTo)
 {
 	auto info = LoadedObjectsById.Find(Id);
 	return info && info->IsValid() ? info->Get()->Clone(this, NewCloneId, true) : nullptr;
 }
 
-UArticyObject* UArticyDatabase::CloneFromByName(FName TechnicalName, int32 NewCloneId)
+UArticyObject* UArticyDatabase::CloneFromByName(FName TechnicalName, int32 NewCloneId, TSubclassOf<class UArticyObject> CastTo)
 {
 	auto arr = LoadedObjectsByName.Find(TechnicalName);
 	if(!arr || arr->Objects.Num() <= 0)

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyDatabase.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyDatabase.cpp
@@ -177,6 +177,11 @@ void UArticyDatabase::UnloadDatabase()
 	}
 }
 
+void UArticyDatabase::SetDefaultUserMethodsProvider(UObject * MethodProvider)
+{
+	GetExpressoInstance()->DefaultUserMethodsProvider = MethodProvider;
+}
+
 UArticyGlobalVariables* UArticyDatabase::GetGVs() const
 {
 	return UArticyGlobalVariables::GetDefault(this);

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
@@ -68,6 +68,24 @@ ExpressoType::ExpressoType(const UArticyPrimitive* Object)
 	StringValue = FString::Printf(TEXT("%d_%d"), Object->GetId(), Object->GetCloneId());
 }
 
+ExpressoType::ExpressoType(const UArticyString& Value)
+{
+	Type = String;
+	StringValue = Value.Get();
+}
+
+ExpressoType::ExpressoType(const UArticyInt & Value)
+{
+	Type = Int;
+	IntValue = Value.Get();
+}
+
+ExpressoType::ExpressoType(const UArticyBool & Value)
+{
+	Type = Bool;
+	BoolValue = Value.Get();
+}
+
 ExpressoType::operator bool() const
 {
 	ensure(Type == Bool);
@@ -473,21 +491,21 @@ UArticyBaseObject* ExpressoType::TryFeatureReroute(UArticyBaseObject* Object, FS
 
 //---------------------------------------------------------------------------//
 
-bool UArticyExpressoScripts::Evaluate(const FName& ConditionFragment, UArticyGlobalVariables* GV, UObject* MethodProvider) const
+bool UArticyExpressoScripts::Evaluate(const int& ConditionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const
 {
 	SetGV(GV);
 	UserMethodsProvider = MethodProvider;
 
-	auto condition = Conditions.Find(ConditionFragment);
+	auto condition = Conditions.Find(ConditionFragmentHash);
 	return ensure(condition) && (*condition)();
 }
 
-bool UArticyExpressoScripts::Execute(const FName& InstructionFragment, UArticyGlobalVariables* GV, UObject* MethodProvider) const
+bool UArticyExpressoScripts::Execute(const int& InstructionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const
 {
 	SetGV(GV);
 	UserMethodsProvider = MethodProvider;
 
-	auto instruction = Instructions.Find(InstructionFragment);
+	auto instruction = Instructions.Find(InstructionFragmentHash);
 	if(ensure(instruction))
 	{
 		(*instruction)();
@@ -501,6 +519,8 @@ UArticyObject* UArticyExpressoScripts::getObj(const FString& NameOrId, const uin
 {
 	if(NameOrId.StartsWith(TEXT("0x")))
 		return OwningDatabase->GetObject<UArticyObject>(FArticyId{ ArticyHelpers::HexToUint64(NameOrId) }, CloneId);
+	if(NameOrId.IsNumeric())
+		return OwningDatabase->GetObject<UArticyObject>(FArticyId{ FCString::Strtoui64(*NameOrId, NULL, 10) }, CloneId);
 
 	return OwningDatabase->GetObjectByName(*NameOrId, CloneId);
 }
@@ -543,4 +563,24 @@ ExpressoType UArticyExpressoScripts::getProp(UArticyBaseObject* Object, const FN
 ExpressoType UArticyExpressoScripts::getProp(const ExpressoType& Id_CloneId, const FName& Property) const
 {
 	return getProp(getObjInternal(Id_CloneId), Property);
+}
+
+int UArticyExpressoScripts::random(int Min, int Max)
+{
+	return FMath::RandRange(Min, Max);
+}
+
+int UArticyExpressoScripts::random(int Max)
+{
+	return FMath::RandRange(0, Max);
+}
+
+float UArticyExpressoScripts::random(float Min, float Max)
+{
+	return FMath::FRandRange(Min, Max);
+}
+
+float UArticyExpressoScripts::random(float Max)
+{
+	return FMath::FRandRange(0, Max);
 }

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
@@ -94,14 +94,22 @@ ExpressoType::operator bool() const
 
 ExpressoType::operator int64() const
 {
-	ensure(Type == Int);
+	ensure(Type == Float || Type == Int);
+
+	if (Type == Float)
+		return GetFloat();
+
 	return GetInt();
 }
 
 ExpressoType::operator double() const
 {
-	ensure(Type == Float);
-	return GetFloat();
+	ensure(Type == Float || Type == Int);
+
+	if(Type == Float)
+		return GetFloat();
+
+	return GetInt();
 }
 
 ExpressoType::operator FString() const

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
@@ -106,7 +106,8 @@ UArticyGlobalVariables* UArticyFlowPlayer::GetGVs() const
 
 UObject* UArticyFlowPlayer::GetMethodsProvider() const
 {
-	auto provider = GetDB()->GetExpressoInstance()->GetUserMethodsProviderInterface();
+	auto expressoInstance = GetDB()->GetExpressoInstance();
+	auto provider = expressoInstance->GetUserMethodsProviderInterface();
 	if(ensure(provider))
 	{
 		//check if the set provider implements the required interface
@@ -138,6 +139,11 @@ UObject* UArticyFlowPlayer::GetMethodsProvider() const
 								break;
 							}
 						}
+
+						//and finally we check for a default methods provider, which we can use as fallback
+						auto defaultUserMethodsProvider = expressoInstance->DefaultUserMethodsProvider;
+						if(defaultUserMethodsProvider && ensure(defaultUserMethodsProvider->GetClass()->ImplementsInterface(provider)))
+							UserMethodsProvider = defaultUserMethodsProvider;
 					}
 				}
 			}

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyFunctionLibrary.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyFunctionLibrary.cpp
@@ -8,7 +8,7 @@
 #include "ArticyObject.h"
 #include "ArticyFlowPlayer.h"
 
-UArticyObject* UArticyFunctionLibrary::ArticyRef_GetObject(const FArticyRef& Ref, const UObject* WorldContext)
+UArticyObject* UArticyFunctionLibrary::ArticyRef_GetObject(const FArticyRef& Ref, TSubclassOf<class UArticyObject> CastTo, const UObject* WorldContext)
 {
 	return Ref.GetObject(WorldContext);
 }
@@ -28,7 +28,7 @@ void UArticyFunctionLibrary::ArticyRef_SetObjectId(FArticyRef& Ref, FArticyId Id
 	Ref.SetId(Id);
 }
 
-UArticyObject* UArticyFunctionLibrary::ArticyId_GetObject(const FArticyId& Id, const UObject* WorldContext)
+UArticyObject* UArticyFunctionLibrary::ArticyId_GetObject(const FArticyId& Id, TSubclassOf<class UArticyObject> CastTo, const UObject* WorldContext)
 {
 	return Cast<UArticyObject>(Id.GetObject(WorldContext));
 }
@@ -56,6 +56,16 @@ bool UArticyFunctionLibrary::ArticyId_NotEqual(const FArticyId& A, const FArticy
 bool UArticyFunctionLibrary::ArticyId_IsValid(const FArticyId & Id)
 {
 	return Id && Id.Low != 0 && Id.High != 0;
+}
+
+FArticyGvName UArticyFunctionLibrary::ArticyGvName_MakeFromFullName(const FName& FullName)
+{
+	return FArticyGvName(FullName);
+}
+
+FArticyGvName UArticyFunctionLibrary::ArticyGvName_MakeFromVariableAndNamespace(const FName& Variable, const FName& Namespace)
+{
+	return FArticyGvName(Variable, Namespace);
 }
 
 TScriptInterface<IArticyFlowObject> UArticyFunctionLibrary::GetBranchTarget(const FArticyBranch& Branch)

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyFunctionLibrary.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyFunctionLibrary.cpp
@@ -13,9 +13,19 @@ UArticyObject* UArticyFunctionLibrary::ArticyRef_GetObject(const FArticyRef& Ref
 	return Ref.GetObject(WorldContext);
 }
 
+void UArticyFunctionLibrary::ArticyRef_SetObject(FArticyRef& Ref, UArticyPrimitive* Object)
+{
+	Ref.SetReference(Object);
+}
+
 FArticyId UArticyFunctionLibrary::ArticyRef_GetObjectId(const FArticyRef& Ref)
 {
 	return Ref.GetId();
+}
+
+void UArticyFunctionLibrary::ArticyRef_SetObjectId(FArticyRef& Ref, FArticyId Id)
+{
+	Ref.SetId(Id);
 }
 
 UArticyObject* UArticyFunctionLibrary::ArticyId_GetObject(const FArticyId& Id, const UObject* WorldContext)
@@ -31,6 +41,21 @@ FArticyId UArticyFunctionLibrary::ArticyId_FromString(const FString& hex)
 FString UArticyFunctionLibrary::ArticyId_ToString(const FArticyId& Id)
 {
 	return ArticyHelpers::Uint64ToHex(Id);
+}
+
+bool UArticyFunctionLibrary::ArticyId_Equal(const FArticyId& A, const FArticyId& B)
+{
+	return A == B;
+}
+
+bool UArticyFunctionLibrary::ArticyId_NotEqual(const FArticyId& A, const FArticyId& B)
+{
+	return A != B;
+}
+
+bool UArticyFunctionLibrary::ArticyId_IsValid(const FArticyId & Id)
+{
+	return Id && Id.Low != 0 && Id.High != 0;
 }
 
 TScriptInterface<IArticyFlowObject> UArticyFunctionLibrary::GetBranchTarget(const FArticyBranch& Branch)

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
@@ -10,6 +10,68 @@
 #include "ArticyPluginSettings.h"
 #include "ArticyFlowPlayer.h"
 
+
+FArticyGvName::FArticyGvName(const FName FullVariableName)
+{
+	SetByFullName(FullVariableName);
+}
+
+FArticyGvName::FArticyGvName(const FName VariableNamespace, const FName VariableName)
+{
+	SetByNamespaceAndVariable(VariableNamespace, VariableName);
+}
+
+void FArticyGvName::SetByFullName(const FName FullVariableName)
+{
+	FString variableString;
+	FString namespaceString;
+	if (FullName.ToString().Split(TEXT("."), &variableString, &namespaceString))
+	{
+		FullName = FullVariableName;
+		Variable = FName(*variableString);
+		Namespace = FName(*namespaceString);
+	}
+}
+
+void FArticyGvName::SetByNamespaceAndVariable(const FName VariableNamespace, const FName VariableName)
+{
+	if (!VariableNamespace.IsNone() && !VariableName.IsNone())
+	{
+		Namespace = VariableNamespace;
+		Variable = VariableName;
+		FullName = FName(*FString::Printf(TEXT("%s.%s"), *Variable.ToString(), *Namespace.ToString()));
+	}
+}
+
+const FName& FArticyGvName::GetNamespace()
+{
+	if(!Namespace.IsNone())
+		return Namespace;
+
+	SetByFullName(FullName);
+	return Namespace;
+}
+
+const FName& FArticyGvName::GetVariable()
+{
+	if(!Variable.IsNone())
+		return Variable;
+
+	SetByFullName(FullName);
+	return Variable;
+}
+
+const FName& FArticyGvName::GetFullName()
+{
+	if(!FullName.IsNone())
+		return FullName;
+
+	SetByNamespaceAndVariable(Namespace, Variable);
+	return FullName;
+}
+
+//---------------------------------------------------------------------------//
+
 uint32 UArticyVariable::GetStoreShadowLevel() const
 {
 	return Store->GetShadowLevel();
@@ -89,34 +151,34 @@ UArticyBaseVariableSet* UArticyGlobalVariables::GetNamespace(const FName Namespa
 	return set;
 }
 
-const bool& UArticyGlobalVariables::GetBoolVariable(const FName Namespace, const FName Variable, bool& bSucceeded)
+const bool& UArticyGlobalVariables::GetBoolVariable(FArticyGvName GvName, bool& bSucceeded)
 {
-	return GetVariableValue<UArticyBool, bool>(Namespace, Variable, bSucceeded);
+	return GetVariableValue<UArticyBool, bool>(GvName.GetNamespace(), GvName.GetVariable(), bSucceeded);
 }
 
-const int32& UArticyGlobalVariables::GetIntVariable(const FName Namespace, const FName Variable, bool& bSucceeded)
+const int32& UArticyGlobalVariables::GetIntVariable(FArticyGvName GvName, bool& bSucceeded)
 {
-	return GetVariableValue<UArticyInt, int32>(Namespace, Variable, bSucceeded);
+	return GetVariableValue<UArticyInt, int32>(GvName.GetNamespace(), GvName.GetVariable(), bSucceeded);
 }
 
-const FString& UArticyGlobalVariables::GetStringVariable(const FName Namespace, const FName Variable, bool& bSucceeded)
+const FString& UArticyGlobalVariables::GetStringVariable(FArticyGvName GvName, bool& bSucceeded)
 {
-	return GetVariableValue<UArticyString, FString>(Namespace, Variable, bSucceeded);
+	return GetVariableValue<UArticyString, FString>(GvName.GetNamespace(), GvName.GetVariable(), bSucceeded);
 }
 
-void UArticyGlobalVariables::SetBoolVariable(const FName Namespace, const FName Variable, const bool Value)
+void UArticyGlobalVariables::SetBoolVariable(FArticyGvName GvName, const bool Value)
 {
-	SetVariableValue<UArticyBool>(Namespace, Variable, Value);
+	SetVariableValue<UArticyBool>(GvName.GetNamespace(), GvName.GetVariable(), Value);
 }
 
-void UArticyGlobalVariables::SetIntVariable(const FName Namespace, const FName Variable, const int32 Value)
+void UArticyGlobalVariables::SetIntVariable(FArticyGvName GvName, const int32 Value)
 {
-	SetVariableValue<UArticyInt>(Namespace, Variable, Value);
+	SetVariableValue<UArticyInt>(GvName.GetNamespace(), GvName.GetVariable(), Value);
 }
 
-void UArticyGlobalVariables::SetStringVariable(const FName Namespace, const FName Variable, const FString Value)
+void UArticyGlobalVariables::SetStringVariable(FArticyGvName GvName, const FString Value)
 {
-	SetVariableValue<UArticyString>(Namespace, Variable, Value);
+	SetVariableValue<UArticyString>(GvName.GetNamespace(), GvName.GetVariable(), Value);
 }
 
 TWeakObjectPtr<UArticyGlobalVariables> UArticyGlobalVariables::Clone;

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
@@ -25,11 +25,11 @@ void FArticyGvName::SetByFullName(const FName FullVariableName)
 {
 	FString variableString;
 	FString namespaceString;
-	if (FullName.ToString().Split(TEXT("."), &variableString, &namespaceString))
+	if (FullVariableName.ToString().Split(TEXT("."), &namespaceString, &variableString))
 	{
 		FullName = FullVariableName;
-		Variable = FName(*variableString);
 		Namespace = FName(*namespaceString);
+		Variable = FName(*variableString);
 	}
 }
 

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyObject.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyObject.cpp
@@ -36,8 +36,17 @@ UArticyObject* UArticyObject::GetParent() const
 	return UArticyDatabase::Get(this)->GetObject<UArticyObject>(Parent);
 }
 
-// ReSharper disable once CppMemberFunctionMayBeStatic
-TArray<UArticyObject*> UArticyObject::GetChildren() const
-{
-	return TArray<UArticyObject*>();
+TArray<TWeakObjectPtr<UArticyObject>> UArticyObject::GetChildren() const
+{	
+	if (CachedChildren.Num() != Children.Num())
+	{
+		auto db = UArticyDatabase::Get(this);
+		CachedChildren.Empty(Children.Num());
+
+		for (auto childId : Children)
+			if (auto child = db->GetObject<UArticyObject>(childId))
+				CachedChildren.Add(child);
+	}
+
+	return CachedChildren;
 }

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyPins.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyPins.cpp
@@ -57,7 +57,14 @@ void UArticyInputPin::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& 
 	if(!bIsValid && Player->IgnoresInvalidBranches())
 		return;
 
-	if(Connections.Num() > 0)
+	IArticyFlowObject* owner = Cast<IArticyFlowObject>(GetOwner());
+
+	if(Depth > 3 && Player->ShouldPauseOn(owner))
+	{
+		// if the owner of this input pin is a stop node, we directly continue with it instead of submerging
+		OutBranches.Append(Player->Explore(owner, false, Depth + 1));
+	}
+	else if(Connections.Num() > 0)
 	{
 		//shadow needed?
 		const auto bShadowed = Connections.Num() > 1;
@@ -72,7 +79,7 @@ void UArticyInputPin::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& 
 	else
 	{
 		//no connections, so continue with the owner itself
-		OutBranches.Append( Player->Explore(Cast<IArticyFlowObject>(GetOwner()), false, Depth+1) );
+		OutBranches.Append( Player->Explore(owner, false, Depth+1) );
 	}
 
 	/**

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyPins.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyPins.cpp
@@ -27,7 +27,7 @@ void UArticyFlowPin::InitFromJson(TSharedPtr<FJsonValue> Json)
 		for (int i = 0; i < items->Num(); ++i)
 		{
 			auto item = (*items)[i];
-			auto conn = NewObject<UArticyOutgoingConnection>(this, "Connection_" + i);
+			auto conn = NewObject<UArticyOutgoingConnection>(this, *FString::Printf(TEXT("Connection_%d'"), i));
 			conn->InitFromJson(item);
 			Connections.Add(conn);
 		}
@@ -45,7 +45,7 @@ UArticyObject* UArticyFlowPin::GetOwner()
 bool UArticyInputPin::Evaluate(class UArticyGlobalVariables* GV, class UObject* MethodProvider)
 {
 	auto db = UArticyDatabase::Get(this);
-	return db->GetExpressoInstance()->Evaluate(Text, GV ? GV : db->GetGVs(), MethodProvider);
+	return db->GetExpressoInstance()->Evaluate(GetTypeHash(Text), GV ? GV : db->GetGVs(), MethodProvider);
 }
 
 void UArticyInputPin::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth)
@@ -92,7 +92,7 @@ void UArticyInputPin::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& 
 void UArticyOutputPin::Execute(class UArticyGlobalVariables* GV, class UObject* MethodProvider)
 {
 	auto db = UArticyDatabase::Get(this);
-	db->GetExpressoInstance()->Execute(Text, GV ? GV : db->GetGVs(), MethodProvider);
+	db->GetExpressoInstance()->Execute(GetTypeHash(Text), GV ? GV : db->GetGVs(), MethodProvider);
 }
 
 void UArticyOutputPin::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth)

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyPluginSettings.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyPluginSettings.cpp
@@ -8,8 +8,8 @@
 UArticyPluginSettings::UArticyPluginSettings()
 {
 	bCreateBlueprintTypeForScriptMethods = true;
-	bKeepDatabaseBetweenWorlds = false;
-	bKeepGlobalVariablesBetweenWorlds = false;
+	bKeepDatabaseBetweenWorlds = true;
+	bKeepGlobalVariablesBetweenWorlds = true;
 }
 
 const UArticyPluginSettings* UArticyPluginSettings::Get()

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyPluginSettings.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyPluginSettings.cpp
@@ -1,0 +1,25 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+//
+#include "ArticyRuntimePrivatePCH.h"
+#include "ArticyPluginSettings.h"
+
+UArticyPluginSettings::UArticyPluginSettings()
+{
+	bCreateBlueprintTypeForScriptMethods = true;
+	bKeepDatabaseBetweenWorlds = false;
+	bKeepGlobalVariablesBetweenWorlds = false;
+}
+
+const UArticyPluginSettings* UArticyPluginSettings::Get()
+{
+	static TWeakObjectPtr<UArticyPluginSettings> Settings;
+
+	if (!Settings.IsValid())
+	{
+		Settings = TWeakObjectPtr<UArticyPluginSettings>(NewObject<UArticyPluginSettings>());
+	}
+
+	return Settings.Get();
+}

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyRef.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyRef.cpp
@@ -79,8 +79,10 @@ bool FArticyRef::Serialize(FArchive& Ar)
 void FArticyRef::PostSerialize(const FArchive& Ar)
 {
 	//we use this as post-loading hook
+#if WITH_EDITOR
 	if(Ar.IsLoading())
 	{
 		GetReference();
 	}
+#endif
 }

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyRef.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyRef.cpp
@@ -43,19 +43,6 @@ UArticyPrimitive* FArticyRef::GetReference()
 	return Reference;
 }
 
-template<>
-UArticyPrimitive* FArticyRef::GetObject(const UObject* WorldContext) const
-{
-	if(!CachedObject.IsValid() || CachedId != Id || CloneId != CachedCloneId)
-	{
-		CachedId = Id;
-		CachedCloneId = CloneId;
-		CachedObject = GetObjectInternal(WorldContext);
-	}
-
-	return CachedObject.Get();
-}
-
 UArticyPrimitive* FArticyRef::GetObjectInternal(const UObject* WorldContext) const
 {
 	if(bReferenceBaseObject)

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyReference.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyReference.cpp
@@ -1,0 +1,28 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+//
+#include "ArticyRuntimePrivatePCH.h"
+
+#include "ArticyReference.h"
+
+
+UArticyReference::UArticyReference()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+}
+
+bool UArticyReference::IsValid()
+{
+	return Reference.GetId().Get() != 0;
+}
+
+UArticyPrimitive* UArticyReference::GetObject(const UObject* WorldContext)
+{
+	return Reference.GetObject<UArticyPrimitive>(WorldContext);
+}
+
+void UArticyReference::SetReference(UArticyPrimitive* Object)
+{
+	Reference.SetReference(Object);
+}

--- a/ArticyImporter/Source/ArticyRuntime/Private/ArticyScriptFragment.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/ArticyScriptFragment.cpp
@@ -7,12 +7,12 @@
 #include "ArticyScriptFragment.h"
 #include "ArticyExpressoScripts.h"
 
-FName UArticyScriptFragment::GetExpression() const
+int UArticyScriptFragment::GetExpressionHash() const
 {
-	if(CachedExpression.IsNone() && !Expression.IsEmpty())
-		CachedExpression = *Expression;
+	if(!CachedExpressionHash)
+		CachedExpressionHash = GetTypeHash(Expression);
 
-	return CachedExpression;
+	return CachedExpressionHash;
 }
 
 void UArticyScriptFragment::InitFromJson(TSharedPtr<FJsonValue> Json)
@@ -33,7 +33,7 @@ void UArticyScriptFragment::InitFromJson(TSharedPtr<FJsonValue> Json)
 bool UArticyScriptCondition::Evaluate(class UArticyGlobalVariables* GV, class UObject* MethodProvider)
 {
 	auto db = UArticyDatabase::Get(this);
-	return db->GetExpressoInstance()->Evaluate(GetExpression(), GV ? GV : db->GetGVs(), MethodProvider);
+	return db->GetExpressoInstance()->Evaluate(GetExpressionHash(), GV ? GV : db->GetGVs(), MethodProvider);
 }
 
 bool UArticyCondition::Evaluate(UArticyGlobalVariables* GV, UObject* MethodProvider)
@@ -63,7 +63,7 @@ void UArticyCondition::Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>&
 void UArticyScriptInstruction::Execute(class UArticyGlobalVariables* GV, class UObject* MethodProvider)
 {
 	auto db = UArticyDatabase::Get(this);
-	db->GetExpressoInstance()->Execute(GetExpression(), GV ? GV : db->GetGVs(), MethodProvider);
+	db->GetExpressoInstance()->Execute(GetExpressionHash(), GV ? GV : db->GetGVs(), MethodProvider);
 }
 
 UArticyScriptCondition* UArticyCondition::GetCondition() const

--- a/ArticyImporter/Source/ArticyRuntime/Private/Interfaces/ArticyOutputPinsProvider.cpp
+++ b/ArticyImporter/Source/ArticyRuntime/Private/Interfaces/ArticyOutputPinsProvider.cpp
@@ -29,5 +29,5 @@ void IArticyOutputPinsProvider::Explore(UArticyFlowPlayer* Player, TArray<FArtic
 const TArray<UArticyOutputPin*>* IArticyOutputPinsProvider::GetOutputPins() const
 {
 	const static auto name = FName("OutputPins");
-	return GetPropPtr<TArray<UArticyOutputPin*>>(name);
+	return Cast<IArticyReflectable>(this)->GetPropPtr<TArray<UArticyOutputPin*>>(name);
 }

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyAsset.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyAsset.h
@@ -42,9 +42,11 @@ public:
 	UTexture* LoadAsTexture() const;
 
 	UFUNCTION(BlueprintCallable, Category="Load Asset")
+	UTexture2D* LoadAsTexture2D() const;
+
+	UFUNCTION(BlueprintCallable, Category="Load Asset")
 	class UFileMediaSource* LoadAsAudio() const;
 
-protected:
 	/** The relative path of the referenced asset. */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Meta Data")
 	FString AssetRef;

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyBaseInclude.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyBaseInclude.h
@@ -29,5 +29,6 @@
 #include "ArticyObjectWithSpeaker.h"
 #include "ArticyObjectWithTarget.h"
 #include "ArticyObjectWithText.h"
+#include "ArticyObjectWithTransform.h"
 #include "ArticyObjectWithVertices.h"
 #include "ArticyObjectWithZIndex.h"

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -344,8 +344,9 @@ TArray<T*> UArticyDatabase::GetObjectsOfClass(int32 CloneId) const
 {
 	TArray<T*> arr;
 	for (auto obj : ArticyObjects)
-		if (obj->GetCloneId() == CloneId && Cast<T>(obj))
-			arr.Add(obj);
+		if (obj->GetCloneId() == CloneId)
+			if (T* castedObj = Cast<T>(obj))
+				arr.Add(castedObj);
 
 	return arr;
 }

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -183,7 +183,11 @@ public:
 	template<typename T>
 	T* GetObject(FArticyId Id, int32 CloneId = 0) const { return Cast<T>(GetObject(Id, CloneId)); }
 
-
+	/** 
+	 * Get an unshadowed copy of an object.
+	 * Internally used by the flow player to replace nodes with unshadowed ones
+	 * before returning them via the flow player callbacks.
+	 */
 	UArticyPrimitive* GetObjectUnshadowed(FArticyId Id, int32 CloneId = 0) const;
 
 	/**

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -171,10 +171,11 @@ public:
 	 * If a CloneId other than 0 is provided, a copy of the object with this index must exist.
 	 * Otherwise a null-pointer is returned.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	UArticyPrimitive* GetObject(FArticyId Id, int32 CloneId = 0) const;
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType="CastTo", AdvancedDisplay="CloneId"))
+	UArticyPrimitive* GetObject(FArticyId Id, int32 CloneId = 0, TSubclassOf<class UArticyObject> CastTo = NULL) const;
 	template<typename T>
 	T* GetObject(FArticyId Id, int32 CloneId = 0) const { return Cast<T>(GetObject(Id, CloneId)); }
+
 
 	UArticyPrimitive* GetObjectUnshadowed(FArticyId Id, int32 CloneId = 0) const;
 
@@ -184,8 +185,8 @@ public:
 	 * otherwise a null-pointer is returned.
 	 * Note that the TechnicalName is not unique! This will take the first matching object.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	UArticyObject* GetObjectByName(FName TechnicalName, int32 CloneId = 0) const;
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType="CastTo", AdvancedDisplay="CloneId"))
+	UArticyObject* GetObjectByName(FName TechnicalName, int32 CloneId = 0, TSubclassOf<class UArticyObject> CastTo = NULL) const;
 	template<typename T>
 	T* GetObjectByName(FName TechnicalName, int32 CloneId = 0) const { return Cast<T>(GetObjectByName(TechnicalName, CloneId)); }
 
@@ -203,8 +204,8 @@ public:
 	 * If a CloneId other than 0 is provided, copies of the objects with this index must exist,
 	 * otherwise null-pointers are returned instead.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	TArray<UArticyObject*> GetObjects(FName TechnicalName, int32 CloneId = 0) const;
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta = (DeterminesOutputType = "CastTo", AdvancedDisplay = "CloneId"))
+	TArray<UArticyObject*> GetObjects(FName TechnicalName, int32 CloneId = 0, TSubclassOf<class UArticyObject> CastTo = NULL) const;
 
 	/**
 	* Get all objects with a given Type.
@@ -212,15 +213,15 @@ public:
 	* otherwise they will be not added to the result.
 	*/
 	template<typename T>
-	TArray<T*> GetObjectsByType(int32 CloneId = 0) const;
+	TArray<T*> GetObjectsOfClass(int32 CloneId = 0) const;
 
 	/**
 	* Get all objects with a given Type.
 	* If a CloneId other than 0 is provided, copies of the objects with this index must exist,
 	* otherwise they will be not added to the result.
 	*/
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	TArray<UArticyObject*> GetObjectsByType(TSubclassOf<class UArticyObject> Type, int32 CloneId = 0) const;
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType = "Class", AdvancedDisplay="CloneId"))
+	TArray<UArticyObject*> GetObjectsOfClass(TSubclassOf<class UArticyObject> Class, int32 CloneId = 0) const;
 
 	/**
 	* Get all objects.
@@ -243,8 +244,8 @@ public:
 	 * If the clone already exists, nullptr is returned!
 	 * If NewCloneId is -1, the next free clone Id will be used.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	UArticyPrimitive* CloneFrom(FArticyId Id, int32 NewCloneId = -1);
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType = "CastTo"))
+	UArticyPrimitive* CloneFrom(FArticyId Id, int32 NewCloneId = -1, TSubclassOf<class UArticyObject> CastTo = NULL);
 	template<typename T>
 	T* CloneFrom(FArticyId Id, int32 NewCloneId = -1) { return Cast<T>(CloneFrom(Id, NewCloneId)); }
 
@@ -253,15 +254,15 @@ public:
 	 * If the clone already exists, nullptr is returned!
 	 * If NewCloneId is -1, the next free clone Id will be used.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
-	UArticyObject* CloneFromByName(FName TechnicalName, int32 NewCloneId = -1);
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType = "CastTo"))
+	UArticyObject* CloneFromByName(FName TechnicalName, int32 NewCloneId = -1, TSubclassOf<class UArticyObject> CastTo = NULL);
 	template<typename T>
 	T* CloneFrom(FName TechnicalName, int32 NewCloneId = -1) { return Cast<T>(CloneFromByName(TechnicalName, NewCloneId)); }
 
 	/**
 	 * Clone an existing object, and assign the NewCloneId to it.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType = "CastTo"))
 	UArticyPrimitive* GetOrClone(FArticyId Id, int32 NewCloneId);
 	template<typename T>
 	T* GetOrClone(FArticyId Id, int32 NewCloneId) { return Cast<T>(GetOrClone(Id, NewCloneId)); }
@@ -269,7 +270,7 @@ public:
 	/**
 	 * Clone an existing object, and assign the NewCloneId to it.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Objects")
+	UFUNCTION(BlueprintCallable, Category = "Objects", meta=(DeterminesOutputType = "CastTo"))
 	UArticyObject* GetOrCloneByName(const FName& TechnicalName, int32 NewCloneId);
 	template<typename T>
 	T* GetOrClone(const FName& TechnicalName, int32 NewCloneId) { return Cast<T>(GetOrCloneByName(TechnicalName, NewCloneId)); }
@@ -332,7 +333,7 @@ TArray<T*> UArticyDatabase::GetObjects(FName TechnicalName, int32 CloneId) const
 }
 
 template<typename T>
-TArray<T*> UArticyDatabase::GetObjectsByType(int32 CloneId) const
+TArray<T*> UArticyDatabase::GetObjectsOfClass(int32 CloneId) const
 {
 	TArray<T*> arr;
 	for (auto obj : ArticyObjects)

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -135,6 +135,13 @@ public:
 	void UnloadDatabase();
 
 	/** 
+	 * Sets a default method provider, which will be always used whenever scripts get
+	 * evaluated / executed without a valid method provider.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Script Methods")
+	void SetDefaultUserMethodsProvider(UObject* MethodProvider);
+
+	/** 
 	 * Returns true if the database is in shadow state.
 	 * Can be used in script methods to determine if the function is called during
 	 * a flow player branch calculation.

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -268,6 +268,7 @@ public:
 public:
 
 	mutable UObject* UserMethodsProvider = nullptr;
+	mutable UObject* DefaultUserMethodsProvider = nullptr;
 
 	/** Sets the GV instance to be used when executing expresso script fragments. */
 	virtual void SetGV(UArticyGlobalVariables* GV) const { }

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -8,7 +8,7 @@
 #include "ArticyRef.h"
 #include "ArticyObject.h"
 #include "ArticyDatabase.h"
-#include "ArticyGlobalVariables.h"
+//#include "ArticyGlobalVariables.h"
 
 #include "ArticyExpressoScripts.generated.h"
 
@@ -71,6 +71,9 @@ struct ARTICYRUNTIME_API ExpressoType
 	ExpressoType(const FText& Value) : ExpressoType(Value.ToString()) {}
 	ExpressoType(const FName& Value) : ExpressoType(Value.ToString()) {}
 	ExpressoType(const UArticyPrimitive* Object);
+	ExpressoType(const UArticyString& Value);
+	ExpressoType(const UArticyInt& Value);
+	ExpressoType(const UArticyBool& Value);
 	
 	//implicit conversion to value type
 	explicit operator bool() const;
@@ -179,6 +182,16 @@ struct ARTICYRUNTIME_API ExpressoType
 	static UArticyBaseObject* TryFeatureReroute(UArticyBaseObject* Object, FString& Property);
 };
 
+FORCEINLINE	int operator+(const int& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs + (int)Rhs;
+}
+
+FORCEINLINE	float operator+(const float& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs + (float)Rhs;
+}
+
 /**
  * The database is used for accessing or cloning any articy object.
  */
@@ -192,8 +205,8 @@ public:
 	UArticyExpressoScripts()
 	{
 		//add empty condition and instruction
-		Conditions.Add(FName{ "" }, [&] { return true; });
-		Instructions.Add(FName{ "" }, [&] { return; });
+		Conditions.Add(GetTypeHash(FString{ "" }), [&] { return true; });
+		Instructions.Add(GetTypeHash(FString{ "" }), [&] { return; });
 	}
 
 	/** Used by the FlowPlayer internally. */
@@ -210,12 +223,12 @@ public:
 	 * Evaluate the condition and return the result.
 	 * Note that the passed in condition is only used as a key to look up a lambda in a map of existing (imported) conditions!
 	 */
-	bool Evaluate(const FName &ConditionFragment, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
+	bool Evaluate(const int &ConditionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
 	/**
 	 * Execute the instruction, and return true (unless the fragment was not found!)
 	 * Note that the passed in condition is only used as a key to look up a lambda in a map of existing (imported) conditions!
 	 */
-	bool Execute(const FName &InstructionFragment, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
+	bool Execute(const int &InstructionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
 
 protected:
 
@@ -237,8 +250,8 @@ protected:
 	 */
 	UArticyObject* speaker = nullptr;
 
-	TMap<FName, TFunction<bool()>> Conditions;
-	TMap<FName, TFunction<void()>> Instructions;
+	TMap<uint32, TFunction<bool()>> Conditions;
+	TMap<uint32, TFunction<void()>> Instructions;
 
 	/** Don't change the name, it's called like this in script fragments! */
 	UArticyObject* getObj(const FString& NameOrId, const uint32& CloneId = 0) const;
@@ -252,6 +265,16 @@ protected:
 	static ExpressoType getProp(UArticyBaseObject* Object, const FName& Property);
 	/** Don't change the name, it's called like this in script fragments! */
 	ExpressoType getProp(const ExpressoType& Id_CloneId, const FName& Property) const;
+
+	/** Don't change the name, it's called like this in script fragments! */
+	int random(int Min, int Max);
+	/** Don't change the name, it's called like this in script fragments! */
+	int random(int Max);
+	/** Don't change the name, it's called like this in script fragments! */
+	float random(float Min, float Max);
+	/** Don't change the name, it's called like this in script fragments! */
+	float random(float Max);
+
 
 	/**
 	 * Prints a string to the log. Can contain placeholders:

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -182,14 +182,49 @@ struct ARTICYRUNTIME_API ExpressoType
 	static UArticyBaseObject* TryFeatureReroute(UArticyBaseObject* Object, FString& Property);
 };
 
-FORCEINLINE	int operator+(const int& Lhs, const ExpressoType& Rhs)
+FORCEINLINE int operator+(const int& Lhs, const ExpressoType& Rhs)
 {
 	return Lhs + (int)Rhs;
 }
 
-FORCEINLINE	float operator+(const float& Lhs, const ExpressoType& Rhs)
+FORCEINLINE int operator-(const int& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs - (int)Rhs;
+}
+
+FORCEINLINE int operator*(const int& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs * (int)Rhs;
+}
+
+FORCEINLINE int operator/(const int& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs / (int)Rhs;
+}
+
+FORCEINLINE int operator%(const int& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs % (int)Rhs;
+}
+
+FORCEINLINE float operator+(const float& Lhs, const ExpressoType& Rhs)
 {
 	return Lhs + (float)Rhs;
+}
+
+FORCEINLINE float operator-(const float& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs - (float)Rhs;
+}
+
+FORCEINLINE float operator*(const float& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs * (float)Rhs;
+}
+
+FORCEINLINE float operator/(const float& Lhs, const ExpressoType& Rhs)
+{
+	return Lhs / (float)Rhs;
 }
 
 /**
@@ -230,7 +265,7 @@ public:
 	 */
 	bool Execute(const int &InstructionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
 
-protected:
+public:
 
 	mutable UObject* UserMethodsProvider = nullptr;
 

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -216,7 +216,7 @@ public:
 	UArticyDatabase* GetDb() const { return OwningDatabase; }
 
 
-	void SetCurrentObject(UArticyObject* Object) { self = Object; }
+	void SetCurrentObject(UArticyPrimitive* Object) { self = Object; }
 	void SetSpeaker(UArticyObject* Speaker) { speaker = Speaker; }
 
 	/**
@@ -243,7 +243,7 @@ protected:
 	 * The current object where the script is evaluated on.
 	 * Don't change the name, it's called like this in script fragments!
 	 */
-	UArticyObject* self = nullptr;
+	UArticyPrimitive* self = nullptr;
 	/**
 	 * Inside a DialogFragment this is a reference to the current speaker.
 	 * Don't change the name, it's called like this in script fragments!

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -265,10 +265,10 @@ public:
 	 */
 	bool Execute(const int &InstructionFragmentHash, UArticyGlobalVariables* GV, UObject* MethodProvider) const;
 
-public:
-
 	mutable UObject* UserMethodsProvider = nullptr;
 	mutable UObject* DefaultUserMethodsProvider = nullptr;
+
+protected:
 
 	/** Sets the GV instance to be used when executing expresso script fragments. */
 	virtual void SetGV(UArticyGlobalVariables* GV) const { }

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -106,6 +106,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Flow")
 	void Play(int Index = 0);
 
+	/** Calls the script on an output pin of the current object */
 	UFUNCTION(BlueprintCallable, Category = "Flow")
 	void FinishCurrentPausedObject(int PinIndex = 0);
 

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -90,6 +90,10 @@ public:
 	UFUNCTION(BlueprintCallable, meta=(DisplayName="Set Start Node (FlowObject)"), Category = "Setup")
 	void SetStartNodeWithFlowObject(TScriptInterface<IArticyFlowObject> Node);
 
+	/** Gets the last set StartOn node */
+	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Get Start Node"), Category = "Setup")
+	FArticyRef GetStartNode() { return StartOn; }
+		
 	/** Set the Cursor (current node) to this Node and updates the available branches. */
 	UFUNCTION(BlueprintCallable, Category = "Flow")
 	void SetCursorTo(TScriptInterface<IArticyFlowObject> Node);
@@ -120,6 +124,9 @@ public:
 	 * If the node is submergeable, a submerge is performed.
 	 */
 	TArray<FArticyBranch> Explore(IArticyFlowObject* Node, bool bShadowed, uint32 Depth);
+
+	/** Returns true if Node is one of the PauseOn types. */
+	bool ShouldPauseOn(IArticyFlowObject* Node) const;
 	
 	/**
 	 * Get the GV instance used for expresso script execution.
@@ -251,9 +258,6 @@ private:
 	 * the path branches out.
 	 */
 	bool FastForwardToPause();
-
-	/** Returns true if Node is one of the PauseOn types. */
-	bool ShouldPauseOn(IArticyFlowObject* Node) const;
 
 	/** Returns a ptr to the unshadowed object of this node */
 	IArticyFlowObject* GetUnshadowedNode(IArticyFlowObject* Node);

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -27,7 +27,7 @@ enum class EArticyPausableType : uint8
 ENUM_CLASS_FLAGS(EArticyPausableType);
 
 USTRUCT(BlueprintType)
-struct FArticyBranch
+struct ARTICYRUNTIME_API FArticyBranch
 {
 	GENERATED_BODY()
 
@@ -83,16 +83,27 @@ public:
 	//---------------------------------------------------------------------------//
 
 	/** Set the StartOn node to a certain node. */
-	UFUNCTION(BlueprintCallable, Category = "Setup")
+	UFUNCTION(BlueprintCallable, meta=(DisplayName="Set Start Node (ArticyRef)"), Category = "Setup")
 	void SetStartNode(FArticyRef NewId);
+
+	/** Set the StartOn node to a certain node. */
+	UFUNCTION(BlueprintCallable, meta=(DisplayName="Set Start Node (FlowObject)"), Category = "Setup")
+	void SetStartNodeWithFlowObject(TScriptInterface<IArticyFlowObject> Node);
 
 	/** Set the Cursor (current node) to this Node and updates the available branches. */
 	UFUNCTION(BlueprintCallable, Category = "Flow")
 	void SetCursorTo(TScriptInterface<IArticyFlowObject> Node);
 
+	/** Get the Cursor (current node). */
+	UFUNCTION(BlueprintCallable, Category = "Flow")
+	const TScriptInterface<IArticyFlowObject> GetCursor() const { return Cursor; }
+
 	/** Play a branch, identified by its index in the AvailableBranches array. */
 	UFUNCTION(BlueprintCallable, Category="Flow")
 	void Play(int Index = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "Flow")
+	void FinishCurrentPausedObject(int PinIndex = 0);
 
 	/**
 	 * Traverse this branch to the end, executing all scripts and updating the Cursor
@@ -138,12 +149,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Setup")
 	bool IgnoresInvalidBranches() const { return bIgnoreInvalidBranches; }
 
-protected:
-
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPushState);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPopState);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnPlayerPaused, TScriptInterface<IArticyFlowObject>, PausedOn);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnBranchesUpdated, const TArray<FArticyBranch>&, AvailableBranches);
+
 
 	/** This event is broadcast whenever a new ShadowedOperation starts. */
 	UPROPERTY(BlueprintAssignable, Category = "Flow")
@@ -165,6 +175,8 @@ protected:
 	 */
 	UPROPERTY(BlueprintAssignable, Category = "Flow")
 	FOnBranchesUpdated OnBranchesUpdated;
+
+protected:
 
 	//========================================//
 
@@ -242,6 +254,9 @@ private:
 
 	/** Returns true if Node is one of the PauseOn types. */
 	bool ShouldPauseOn(IArticyFlowObject* Node) const;
+
+	/** Returns a ptr to the unshadowed object of this node */
+	IArticyFlowObject* GetUnshadowedNode(IArticyFlowObject* Node);
 
 	UArticyDatabase* GetDB() const;
 	UArticyExpressoScripts* GetExpresso() const;

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
@@ -19,25 +19,41 @@ class ARTICYRUNTIME_API UArticyFunctionLibrary : public UBlueprintFunctionLibrar
 	
 public:
 	/** Converts an ArticyRef to an object. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "GetObject", DefaultToSelf = "WorldContext"), Category="ArticyRef")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext"), Category="ArticyRef")
 	static UArticyObject* ArticyRef_GetObject(UPARAM(Ref) const FArticyRef& Ref, const UObject* WorldContext);
+	/** Sets the referenced object of an ArticyRef */
+	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Set Object", DefaultToSelf = "WorldContext"), Category = "ArticyRef")
+	static void ArticyRef_SetObject(UPARAM(Ref) FArticyRef& Ref, UPARAM(Ref) UArticyPrimitive* Object);
 	/** Converts an ArticyRef to FArticyId. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "GetObjectId", DefaultToSelf = "WorldContext", BlueprintAutoCast), Category="ArticyRef")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object Id", DefaultToSelf = "WorldContext", BlueprintAutoCast), Category="ArticyRef")
 	static FArticyId ArticyRef_GetObjectId(UPARAM(Ref) const FArticyRef& Ref);
+	/** Sets the referenced object of an ArticyRef */
+	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Set Object Id", DefaultToSelf = "WorldContext", BlueprintAutoCast), Category = "ArticyRef")
+	static void ArticyRef_SetObjectId(UPARAM(Ref) FArticyRef& Ref, UPARAM(Ref) FArticyId Id);
 
 	/** Converts an ArticyId to an object. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "GetObject", DefaultToSelf = "WorldContext"), Category="ArticyId")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext"), Category="ArticyId")
 	static UArticyObject* ArticyId_GetObject(UPARAM(Ref) const FArticyId& Id, const UObject* WorldContext);
 
 	/** Creates an ArticyId from a hex string. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "ToArticyId"), Category="ArticyId")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "To Articy Id"), Category="ArticyId")
 	static FArticyId ArticyId_FromString(UPARAM(Ref) const FString& hex);
 
 	/** Gets the HEX string from an ID. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "ToHexString"), Category="ArticyId")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "To Hex String"), Category="ArticyId")
 	static FString ArticyId_ToString(UPARAM(Ref) const FArticyId& Id);
 
+	/** Returns true if ArticyId A is equal to ArticyId B */
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Equal (ArticyId)", CompactNodeTitle = "==", Keywords = "== equal"), Category = "ArticyId")
+	static bool ArticyId_Equal(const FArticyId& A, const FArticyId& B);
+	/** Returns true if ArticyId A is not equal to ArticyId B */
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Not Equal (ArticyId)", CompactNodeTitle = "!=", Keywords = "!= not equal"), Category = "ArticyId")
+	static bool ArticyId_NotEqual(const FArticyId& A, const FArticyId& B);
+	/** Returns true if ArticyId is valid: object non-null and underlying id non-zero */
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Is Valid"), Category = "ArticyId")
+	static bool ArticyId_IsValid(const FArticyId& Id);
+
 	/** Gets the last object in a branch. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "GetTarget"), Category="ArticyBranch")
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Target"), Category="ArticyBranch")
 	static TScriptInterface<class IArticyFlowObject> GetBranchTarget(UPARAM(ref) const struct FArticyBranch& Branch);
 };

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
@@ -19,8 +19,8 @@ class ARTICYRUNTIME_API UArticyFunctionLibrary : public UBlueprintFunctionLibrar
 	
 public:
 	/** Converts an ArticyRef to an object. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext"), Category="ArticyRef")
-	static UArticyObject* ArticyRef_GetObject(UPARAM(Ref) const FArticyRef& Ref, const UObject* WorldContext);
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext", DeterminesOutputType = "CastTo"), Category="ArticyRef")
+	static UArticyObject* ArticyRef_GetObject(UPARAM(Ref) const FArticyRef& Ref, TSubclassOf<class UArticyObject> CastTo, const UObject* WorldContext);
 	/** Sets the referenced object of an ArticyRef */
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Set Object", DefaultToSelf = "WorldContext"), Category = "ArticyRef")
 	static void ArticyRef_SetObject(UPARAM(Ref) FArticyRef& Ref, UPARAM(Ref) UArticyPrimitive* Object);
@@ -32,8 +32,8 @@ public:
 	static void ArticyRef_SetObjectId(UPARAM(Ref) FArticyRef& Ref, UPARAM(Ref) FArticyId Id);
 
 	/** Converts an ArticyId to an object. */
-	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext"), Category="ArticyId")
-	static UArticyObject* ArticyId_GetObject(UPARAM(Ref) const FArticyId& Id, const UObject* WorldContext);
+	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Object", DefaultToSelf = "WorldContext", DeterminesOutputType = "CastTo"), Category="ArticyId")
+	static UArticyObject* ArticyId_GetObject(UPARAM(Ref) const FArticyId& Id, TSubclassOf<class UArticyObject> CastTo, const UObject* WorldContext);
 
 	/** Creates an ArticyId from a hex string. */
 	UFUNCTION(BlueprintPure, meta=(DisplayName = "To Articy Id"), Category="ArticyId")

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyFunctionLibrary.h
@@ -53,6 +53,12 @@ public:
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "Is Valid"), Category = "ArticyId")
 	static bool ArticyId_IsValid(const FArticyId& Id);
 
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Make ArticyGvName from full name"), Category = "ArticyId")
+	static FArticyGvName ArticyGvName_MakeFromFullName(const FName& FullName);
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Make ArticyGvName from namespace & variable"), Category = "ArticyId")
+	static FArticyGvName ArticyGvName_MakeFromVariableAndNamespace(const FName& Variable, const FName& Namespace);
+
+
 	/** Gets the last object in a branch. */
 	UFUNCTION(BlueprintPure, meta=(DisplayName = "Get Target"), Category="ArticyBranch")
 	static TScriptInterface<class IArticyFlowObject> GetBranchTarget(UPARAM(ref) const struct FArticyBranch& Branch);

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -153,9 +153,6 @@ public:
 	int& operator-=(const int &Val) { return *this = Value - Val; }
 	int& operator*=(const int &Val) { return *this = Value * Val; }
 	int& operator/=(const int &Val) { return *this = Value / Val; }
-	const int& operator>=(const int &Val) { return *this = Value >= Val; }
-	const int& operator<=(const int &Val) { return *this = Value <= Val; }
-	const int& operator==(const int &Val) { return *this = Value == Val; }
 
 	int& operator=(const ExpressoType &NewValue)
 	{

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -493,12 +493,3 @@ const VariablePayloadType& UArticyGlobalVariables::GetVariableValue(const FName 
 	static VariablePayloadType empty = VariablePayloadType();
 	return empty;
 }
-
-template<typename ArticyVariableType, typename VariablePayloadType>
-const VariablePayloadType& UArticyGlobalVariables::GetVariableValue(const FName FullVariableName, bool& bSucceeded)
-{
-	FString Namespace;
-	FString Variable;
-	FullVariableName.ToString().Split(TEXT("."), &Namespace, &Variable);
-	return GetVariableValue<ArticyVariableType, VariablePayloadType>(FName(*Namespace), FName(*Variable), bSucceeded);
-}

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -154,14 +154,6 @@ public:
 	int& operator*=(const int &Val) { return *this = Value * Val; }
 	int& operator/=(const int &Val) { return *this = Value / Val; }
 
-	int& operator=(const ExpressoType &NewValue)
-	{
-		if (NewValue.Type == ExpressoType::Float) // getProp return value could contain a float
-			return Value = NewValue.GetFloat();
-		else
-			return Value = NewValue.GetInt();
-	}
-
 	int operator++(int)
 	{
 		int copy = *this;
@@ -177,6 +169,46 @@ public:
 		return copy;
 	}
 	int& operator--() { return *this = Value + 1; }
+
+	int& operator=(const ExpressoType &NewVal)
+	{
+		if (NewVal.Type == ExpressoType::Float)
+			return Value = NewVal.GetFloat();
+		else
+			return Value = NewVal.GetInt();
+	}
+
+	int& operator+=(const ExpressoType &Val)
+	{
+		if (Val.Type == ExpressoType::Float)
+			return *this = Value + Val.GetFloat();
+		else
+			return *this = Value + Val.GetInt();
+	}
+
+	int& operator-=(const ExpressoType &Val)
+	{
+		if (Val.Type == ExpressoType::Float)
+			return *this = Value - Val.GetFloat();
+		else
+			return *this = Value - Val.GetInt();
+	}
+
+	int& operator*=(const ExpressoType &Val)
+	{
+		if (Val.Type == ExpressoType::Float)
+			return *this = Value * Val.GetFloat();
+		else
+			return *this = Value * Val.GetInt();
+	}
+
+	int& operator/=(const ExpressoType &Val)
+	{
+		if (Val.Type == ExpressoType::Float)
+			return *this = Value / Val.GetFloat();
+		else
+			return *this = Value / Val.GetInt();
+	}
 
 protected:
 	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
@@ -250,7 +282,9 @@ public:
 	ARTICY_VARIABLE_ACCESS(FString)
 
 	//other operators
-	FString& operator+=(const FString &Val) { return Setter<UArticyString>(Value + Val); }
+	//FString& operator+=(const FString &Val) { return Setter<UArticyString>(Value + Val); }
+
+	FString& operator+=(const ExpressoType &Val) { return Setter<UArticyString>(Value + Val.GetString()); }
 
 	FString& operator=(const ExpressoType &NewValue)
 	{

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -156,7 +156,10 @@ public:
 
 	int& operator=(const ExpressoType &NewValue)
 	{
-		return Value = NewValue.GetInt();
+		if (NewValue.Type == ExpressoType::Float) // getProp return value could contain a float
+			return Value = NewValue.GetFloat();
+		else
+			return Value = NewValue.GetInt();
 	}
 
 	int operator++(int)

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyHelpers.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyHelpers.h
@@ -79,6 +79,13 @@ inline FString Uint64ToHex(uint64 id)
 	return UTF8_TO_TCHAR(stream.str().c_str());
 }
 
+inline FString Uint64ToObjectString(uint64 id)
+{
+	std::ostringstream stream;
+	stream << id << "_0";
+	return UTF8_TO_TCHAR(stream.str().c_str());
+}
+
 inline FVector2D ParseFVector2DFromJson(const TSharedPtr<FJsonValue> Json)
 {
 	if(!Json.IsValid() || !ensure(Json->Type == EJson::Object))

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyObject.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyObject.h
@@ -20,17 +20,22 @@ class ARTICYRUNTIME_API UArticyObject : public UArticyPrimitive
 
 public:
 	FName GetTechnicalName() const;
-
 	UArticyObject* GetParent() const;
-	TArray<UArticyObject*> GetChildren() const;
+	TArray<TWeakObjectPtr<UArticyObject>> GetChildren() const;
 
 protected:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	FArticyId Parent;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	TArray<FArticyId> Children;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	FString TechnicalName;
 
 	/** Used internally by ArticyImporter. */
 	void InitFromJson(TSharedPtr<FJsonValue> Json) override;
+
+private:
+
+	mutable TArray<TWeakObjectPtr<UArticyObject>> CachedChildren;
 };

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyPins.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyPins.h
@@ -25,7 +25,7 @@ class ARTICYRUNTIME_API UArticyFlowPin : public UArticyPrimitive, public IArticy
 public:
 	/** The script fragment. */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
-	FName Text = "";
+	FString Text = "";
 
 	/** The Id of the object owning this pin. */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyPluginSettings.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyPluginSettings.h
@@ -1,0 +1,38 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+//
+#pragma once
+
+#include "ArticyPluginSettings.generated.h"
+
+
+UCLASS(config = Engine, defaultconfig)
+class ARTICYRUNTIME_API UArticyPluginSettings : public UObject
+{
+	GENERATED_BODY() 
+
+public:
+	UArticyPluginSettings();
+
+	/**
+	 * Exposes the generated method provider interface to Blueprint. 
+	 * INFO: Generated functions will be named according to the format <MethodName>_<ArgumentTypes> as a workaround to support overloaded functions in blueprint.
+	*/
+	UPROPERTY(EditAnywhere, config, Category=ImportSettings, meta=(DisplayName="Create Blueprint type for script method interface"))
+	bool bCreateBlueprintTypeForScriptMethods;
+
+	/* --------------------------------------------------------------------- */
+
+	/** Keeps one instance of the database for the whole game alive, even if the world changes */
+	UPROPERTY(EditAnywhere, config, Category=RuntimeSettings, meta=(DisplayName="Keep database between worlds"))
+	bool bKeepDatabaseBetweenWorlds;
+
+	/** Keeps one instance of the global variables for the whole game alive, even if the world changes */
+	UPROPERTY(EditAnywhere, config, Category=RuntimeSettings, meta=(DisplayName="Keep global variables between worlds"))
+	bool bKeepGlobalVariablesBetweenWorlds;
+
+	/* --------------------------------------------------------------------- */
+
+	static const UArticyPluginSettings* Get();
+};

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyRef.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyRef.h
@@ -9,8 +9,8 @@
 #include "ArticyRef.generated.h"
 
 /**
- * 
- */
+*
+*/
 USTRUCT(BlueprintType)
 struct ARTICYRUNTIME_API FArticyRef
 {
@@ -24,7 +24,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Setup")
 	bool bReferenceBaseObject = true;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(EditCondition="!bReferenceBaseObject"), Category="Setup")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (EditCondition="!bReferenceBaseObject"), Category="Setup")
 	mutable int32 CloneId;
 
 	void SetId(FArticyId NewId);

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyRef.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyRef.h
@@ -71,6 +71,19 @@ T* FArticyRef::GetObject(const UObject* WorldContext) const
 }
 
 template<>
+inline UArticyPrimitive* FArticyRef::GetObject(const UObject* WorldContext) const
+{
+	if (!CachedObject.IsValid() || CachedId != Id || CloneId != CachedCloneId)
+	{
+		CachedId = Id;
+		CachedCloneId = CloneId;
+		CachedObject = GetObjectInternal(WorldContext);
+	}
+
+	return CachedObject.Get();
+}
+
+template<>
 struct TStructOpsTypeTraits<FArticyRef> : public TStructOpsTypeTraitsBase2<FArticyRef>
 {
 	enum

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyReference.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyReference.h
@@ -1,0 +1,40 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+//
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ArticyRef.h"
+#include "Components/ActorComponent.h"
+#include "ArticyReference.generated.h"
+
+
+/**
+* Component to hold a single ArticyRef.
+* While you can use ArticyRef in your scripts directly, ArticyReference is most useful in generated code or as a simple way for designers to attach articy objects to actors
+*/
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class ARTICYRUNTIME_API UArticyReference : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	UArticyReference();
+
+	/** The ArticyRef, which this component holds */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Objects")
+	FArticyRef Reference;
+
+	/** Get a value indicating wether the id of the referenced object is valid */
+	UFUNCTION(BlueprintCallable, Category = "Objects")
+	bool IsValid();
+	/** Get the referenced object */
+	UFUNCTION(BlueprintCallable, Category = "Objects")
+	UArticyPrimitive* GetObject(const UObject* WorldContext);
+	/** Set the referenced object */
+	UFUNCTION(BlueprintCallable, Category = "Objects")
+	void SetReference(UArticyPrimitive* Object);
+	
+};

--- a/ArticyImporter/Source/ArticyRuntime/Public/ArticyScriptFragment.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/ArticyScriptFragment.h
@@ -20,12 +20,11 @@ class ARTICYRUNTIME_API UArticyScriptFragment : public UArticyPrimitive
 
 protected:
 
-	//for some reason, the editor crashes on save if this property is an FName
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	FString Expression = "";
 
-	//returns a cached FName version of the expression
-	FName GetExpression() const;
+	//returns a cached hash of the expression
+	int GetExpressionHash() const;
 
 	template<typename Type, typename PropType>
 		friend struct ArticyObjectTypeInfo;
@@ -34,7 +33,7 @@ protected:
 
 private:
 
-	mutable FName CachedExpression = "";
+	mutable int CachedExpressionHash;
 };
 
 /** -------------------------------------------------------------------------------- */

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyConditionProvider.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyConditionProvider.h
@@ -19,7 +19,7 @@ class IArticyConditionProvider
 
 public:
 
-	UFUNCTION(BlueprintCallable, Category="Condition")
+	UFUNCTION(BlueprintCallable, Category="Condition", meta=(AdvancedDisplay="GV, MethodProvider"))
 	virtual bool Evaluate(class UArticyGlobalVariables* GV = nullptr, class UObject* MethodProvider = nullptr) { return true; }
 
 	/*virtual bool Execute(class UArticyGlobalVariables* GV = nullptr, class UObject* MethodProvider = nullptr)

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyFlowObject.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyFlowObject.h
@@ -8,14 +8,14 @@
 #include "ArticyReflectable.h"
 #include "ArticyFlowObject.generated.h"
 
-UINTERFACE()
+UINTERFACE(MinimalAPI, BlueprintType)
 class UArticyFlowObject : public UArticyReflectable { GENERATED_BODY() };
 
 /**
  * All objects that are part of a flow (i.e. can be traversed by the Flow Player) need
  * to implement this interface.
  */
-class IArticyFlowObject : public IArticyReflectable
+class IArticyFlowObject
 {
 	GENERATED_BODY()
 

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
@@ -38,7 +38,7 @@ public:
 			//it must be a shadowed explore
 			const auto bShadowed = bForceShadowed
 									|| inPins->Num() > 1
-									|| (*inPins)[0] && (*inPins)[0]->Connections.Num() > 1;
+									|| ((*inPins)[0] && (*inPins)[0]->Connections.Num() > 1);
 
 			//submerge!
 			for(auto pin : *inPins)
@@ -56,12 +56,10 @@ public:
 
 		return bSubmerged;
 	}
-
-private:
 	
 	const TArray<UArticyInputPin*>* GetInputPins() const
 	{
 		const static auto name = FName("InputPins");
-		return GetPropPtr<TArray<UArticyInputPin*>>(name);
+		return Cast<IArticyReflectable>(this)->GetPropPtr<TArray<UArticyInputPin*>>(name);
 	}
 };

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyInstructionProvider.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyInstructionProvider.h
@@ -19,6 +19,6 @@ class IArticyInstructionProvider
 
 public:
 
-	UFUNCTION(BlueprintCallable, Category="Instruction")
+	UFUNCTION(BlueprintCallable, Category="Instruction", meta=(AdvancedDisplay="GV, MethodProvider"))
 	virtual void Execute(class UArticyGlobalVariables* GV = nullptr, class UObject* MethodProvider = nullptr) { }
 };

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithAttachments.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithAttachments.h
@@ -8,7 +8,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithAttachments.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithAttachments : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithColor.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithColor.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithColor.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithColor : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithDisplayName.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithDisplayName.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithDisplayName.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithDisplayName : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithExternalId.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithExternalId.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithExternalId.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithExternalId : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithMenuText.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithMenuText.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithMenuText.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithMenuText : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPosition.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPosition.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithPosition.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithPosition : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPreviewImage.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPreviewImage.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithPreviewImage.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithPreviewImage : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithShortId.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithShortId.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithShortId.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithShortId : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "ArticyBaseTypes.h"
 #include "ArticyObjectWithSize.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithSize.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithSize : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSpeaker.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSpeaker.h
@@ -5,9 +5,13 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "ArticyBaseTypes.h"
+#include "ArticyObject.h"
 #include "ArticyObjectWithSpeaker.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+struct FArticyId;
+
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithSpeaker : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithStageDirections.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithStageDirections.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithStageDirections.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithStageDirections : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTarget.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTarget.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithTarget.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithTarget : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithText.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithText : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTransform.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTransform.h
@@ -1,0 +1,41 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+//
+#pragma once
+
+#include "ArticyObjectWith_Base.h"
+#include "ArticyObjectWithTransform.generated.h"
+
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+class UArticyObjectWithTransform : public UArticyObjectWith_Base { GENERATED_BODY() };
+
+/**
+ * All objects that have a property called 'Transform' implement this interface.
+ */
+class IArticyObjectWithTransform : public IArticyObjectWith_Base
+{
+	GENERATED_BODY()
+
+public:
+	
+	UFUNCTION(BlueprintCallable, Category="ArticyObjectWithTransform")
+	virtual UArticyTransformation*& GetTransform()
+	{
+		static const auto PropName = FName("Transform");
+		return GetProperty<UArticyTransformation*>(PropName);
+	}
+
+	virtual const UArticyTransformation* GetTransform() const
+	{
+		return const_cast<IArticyObjectWithTransform*>(this)->GetTransform();
+	}
+	
+	//---------------------------------------------------------------------------//
+
+	UFUNCTION(BlueprintCallable, Category="ArticyObjectWithTransform")
+	virtual UArticyTransformation*& SetTransform(UArticyTransformation* Transform)
+	{
+		return GetTransform() = Transform;
+	}
+};

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithVertices.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithVertices.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithVertices.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithVertices : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithZIndex.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithZIndex.h
@@ -7,7 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithZIndex.generated.h"
 
-UINTERFACE(BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWithZIndex : public UArticyObjectWith_Base { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWith_Base.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWith_Base.h
@@ -7,7 +7,7 @@
 #include "ArticyReflectable.h"
 #include "ArticyObjectWith_Base.generated.h"
 
-UINTERFACE(meta=(CannotImplementInterfaceInBlueprint))
+UINTERFACE(MinimalAPI, meta=(CannotImplementInterfaceInBlueprint))
 class UArticyObjectWith_Base : public UArticyReflectable { GENERATED_BODY() };
 
 /**

--- a/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyOutputPinsProvider.h
+++ b/ArticyImporter/Source/ArticyRuntime/Public/Interfaces/ArticyOutputPinsProvider.h
@@ -23,7 +23,5 @@ public:
 
 	void Explore(UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth) override;
 
-protected:
-
 	const TArray<UArticyOutputPin*>* GetOutputPins() const;
 };

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Your file should now look something like this:
 // Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
 
 using UnrealBuildTool;
+using System.IO;
 
 public class MyArticyProject : ModuleRules
 {
@@ -89,8 +90,8 @@ public class MyArticyProject : ModuleRules
 								"HeadMountedDisplay",
 								"ArticyRuntime"
 							});
-		
-		PublicIncludePaths.AddRange(new string[] {"ArticyRuntime/Public"});
+
+		PublicIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "../../Plugins/ArticyImporter/Source/ArticyRuntime/Public") });
 	}
 }
 ```
@@ -172,7 +173,7 @@ Dealing with templates is a bit more complicated. First thing to understand is t
 The name of your template types also follows a similar structure as the one mentioned before, but utilizing the Templates technical name: `<ProjectName><TemplateTechnicalName>`. So if your project is called *ManiacManfred* and your templates technical name is *Conditional_Zone* your correct type would be called `ManiacManfredConditional_Zone`.
 Its also worth mentioning that even if it is a new type, it is still derived from the base type with all its properties.
 
-Accessing is easy once you have cast the object into the correct type, just drag a connection out of the cast node and search for the type to see all its properties.
+Accessing is easy once you have cast the object into the correct type, just drag a connection out of the node and search for the type to see all its properties.
 
 <p align="center">
   <img src="https://www.nevigo.com/articy-importer/unreal/base_object_propertylist.png">
@@ -189,7 +190,7 @@ Some properties are a bit more complex like reference strips and scripts etc:
 
 So to reiterate:
 
-1. Cast object to appropriate type.
+1. Get object and cast to appropriate type.
 2. Access the property/feature.
 3. If it is a feature you access now the property inside the feature. <br/>
 3a. If it is a script method, you can execute it via the `Evaluate` method.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For unreal to correctly build the plugin we need to add it as an dependency, to 
 
 And open it in your favorite text or code editor.
 
-Now we need to adjust the existing code and make sure that the Importer is an dependency for the project. Locate the `PublicDependencyModuleNames` array and add `"ArticyRuntime"` as an additional dependency. You should also add the plugin header files to the public include path by adding `PublicIncludePaths.AddRange(new string[] {"ArticyRuntime/Public"});` below the dependencies.
+Now we need to adjust the existing code and make sure that the Importer is an dependency for the project. Locate the `PublicDependencyModuleNames` array and add `"ArticyRuntime"` as an additional dependency. You should also add the plugin header files to the public include path by adding `PublicIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "../../Plugins/ArticyImporter/Source/ArticyRuntime/Public") });` below the dependencies.
 Your file should now look something like this:
 
 ```


### PR DESCRIPTION
 - ADDED: plugin settings (can be found under Edit -> Project Settings -> Plugins- > Articy Importer)
 - ADDED: possibility to keep one instance of the articy database / global variables for the whole game alive (can be toggled via plugin settings)
 - ADDED: support for overloaded user script methods (Generated functions will be named according to the format <MethodName>_<ArgumentTypes> as a workaround to support overloaded functions in Blueprint. This behaviour can be turned off for C++ users in the plugin settings).
 - ADDED: UArticyDatabase::IsInShadowState, which can be used in the implementation of script methods to determine if a the function is called during a branch calculation
 - ADDED: "CastTo" pin for GetObject nodes
 - ADDED: ArticyGvName struct, used for easier global variable access (especially in blueprint) without building or splitting variable names via string functions
 - ADDED: UArticyDatabase::SetDefaultUserMethodsProvider
 - ADDED: UArticyDatabase::GetAllObjects
 - ADDED: UArticyDatabase::GetObjectByType
 - ADDED: GetChildren logic for articy objects
 - ADDED: UArticyGlobalVariables::GetVariableSets and UArticyBaseVariableSet::GetVariables
 - ADDED: convenience blueprint nodes to articy blueprint function library for usage of articy ids and articy refs
 - ADDED: UArticyAsset::LoadAsTexture2D
 - ADDED: UArticyFlowPlayer::SetStartNode(TScriptInterface<IArticyFlowObject>) overload
 - ADDED: UArticyFlowPlayer::FinishCurrentPausedObject, which can be called when leaving the flow to ensure that the output pin on the current node gets executed.
 - ADDED: missing random function for expresso scripts
 - ADDED: ArticyReference actor component
 - CHANGED: using now an int hash for determining which expresso script should get called (fixes crashes in importer and runtime, as well generation of code that cannot compile).
 - CHANGED: folding the CloneId pin for GetObject nodes and the execute/eveluate node pins
 - FIXED: conversation and operator overloading issues related to expresso scripts and global variables
 - FIXED: issues on Android, Linux, Mac and HTML5 (work in progress)
 - FIXED: initialization of global string variables
 - FIXED: storing a string object representation of an articy object in global variables
 - FIXED: flow player’s OnPlayerPaused & OnBranchesUpdated broadcasted even if cursor or PauseOn was not set
 - FIXED: flow player did not recognized input pin owner as stop nodes
 - FIXED: missing transformation interface
 - FIXED: branch's path consisted of pointers to shadowed objects
 - FIXED: UArticyFlowPlayer::Play(int) considered invalid branches
 - FIXED: calling method provider interface function via Blueprint
 - FIXED: using "speaker" or "self" as param or return value in script methods
 - FIXED: initialization of speaker and self for pins
 - FIXED: particular invalid generated code for script fragments with comments
 - FIXED: floating point numbers and feature names with underscores in script fragments were parsed as variables
 - FIXED: crash when using too long script fragment expressions
 - FIXED: mixed usage of int and float props in expresso scripts
 - FIXED: path in UArticyAsset::GetAsset
 - FIXED: FArticyRef::GetObject template specialization
 - FIXED: linker error when casting to an articy interface in C++
 - FIXED: linker error when calling FArticyBranch::GetTarget in C++
 - FIXED: missing base class BeginPlay call in UArticyFlowPlayer::BeginPlay
 - MODIFIED: Exposed some functions and variables for C++ or Blueprint usage
 - MODIFIED: UE 4.19 API changes
 - MODIFIED: UE 4.20 API changes