### PR TITLE
Fix invalid code generation for interfaces.

### DIFF
--- a/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/InterfacesGenerator.cpp
+++ b/ArticyImporter/Source/ArticyImporter/Private/CodeGeneration/InterfacesGenerator.cpp
@@ -13,7 +13,8 @@ void InterfacesGenerator::GenerateCode(const UArticyImportData* Data)
 	CodeFileGenerator(CodeGenerator::GetGeneratedInterfacesFilename(Data)+".h", true, [&](CodeFileGenerator* header)
 	{
 		header->Line("#include \"CoreUObject.h\"");
-		header->Line("#include \"" + CodeGenerator::GetGeneratedInterfacesFilename(Data) + ".generated.h\"");
+		if(Data->GetObjectDefs().GetFeatures().Num() > 0)
+			header->Line("#include \"" + CodeGenerator::GetGeneratedInterfacesFilename(Data) + ".generated.h\"");
 		header->Line();
 
 		for (auto pair : Data->GetObjectDefs().GetFeatures())


### PR DESCRIPTION
Fixed invalid code generation in InterfacesGenerator when the imported data has no interfaces.
If there are no Interface classes generated Unreal won't generate any ".generated.h" file so it shouldn't be included or the file won't compile.