### PR TITLE
Add Linux support

### DIFF
--- a/ArticyImporter.uplugin
+++ b/ArticyImporter.uplugin
@@ -25,7 +25,8 @@
 				"Win64",
 				"Mac",
 				"IOS",
-				"Android"
+				"Android",
+				"Linux"
 			]
 		},
 		{
@@ -37,7 +38,8 @@
 				"Win64",
 				"Mac",
 				"IOS",
-				"Android"
+				"Android",
+				"Linux"
 			]
 		}
 	]

--- a/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
+++ b/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
@@ -646,7 +646,7 @@ const FName& FArticyObjectDefinitions::GetProviderInterface(const FArticyPropert
 	static TMap<FName, FName> ProviderInterfaces;
 	if(ProviderInterfaces.Num() == 0)
 	{
-		#define OBJECT_WITH_X(x) TEXT(x), TEXT("IArticyObjectWith"x)
+		#define OBJECT_WITH_X(x) TEXT(x), TEXT("IArticyObjectWith" x)
 
 		ProviderInterfaces.Add(OBJECT_WITH_X("Attachments"));
 		ProviderInterfaces.Add(OBJECT_WITH_X("Color"));

--- a/Source/ArticyEditor/Public/ArticyEditorModule.h
+++ b/Source/ArticyEditor/Public/ArticyEditorModule.h
@@ -17,7 +17,14 @@ DECLARE_MULTICAST_DELEGATE_OneParam(FOnCompilationFinished, UArticyImportData*);
 
 class FToolBarBuilder;
 class FMenuBuilder;
-enum EImportStatusValidity;
+
+enum EImportStatusValidity
+{
+	Valid,
+	ImportantAssetMissing,
+	FileMissing,
+	ImportDataAssetMissing
+};
 
 class FArticyEditorModule : public IModuleInterface
 {
@@ -66,12 +73,4 @@ private:
 	FDelegateHandle GeneratedCodeWatcherHandle;
 	FArticyEditorConsoleCommands* ConsoleCommands = nullptr;
 	TSharedPtr<FUICommandList> PluginCommands;
-};
-
-enum EImportStatusValidity
-{
-	Valid,
-	ImportantAssetMissing,
-	FileMissing,
-	ImportDataAssetMissing
 };


### PR DESCRIPTION
For the most part, it works out of the box after enabling the platform. I got two compilation errors:

```
In file included from /home/raptor/projects/Unreal/MyProject4/Plugins/ArticyImporterForUnreal/Intermediate/Build/Linux/B4D820EA/UE4Editor/Development/ArticyEditor/Module.ArticyEditor.cpp:3:
In file included from /home/raptor/projects/Unreal/MyProject4/Plugins/ArticyImporterForUnreal/Source/ArticyEditor/Private/ArticyEditorFunctionLibrary.cpp:8:
/home/raptor/projects/Unreal/MyProject4/Plugins/ArticyImporterForUnreal/Source/ArticyEditor/Public/ArticyEditorModule.h:20:6: error: ISO C++ forbids forward references to 'enum' types
enum EImportStatusValidity;
     ^
In file included from /home/raptor/projects/Unreal/MyProject4/Plugins/ArticyImporterForUnreal/Intermediate/Build/Linux/B4D820EA/UE4Editor/Development/ArticyEditor/Module.ArticyEditor.cpp:18:
/home/raptor/projects/Unreal/MyProject4/Plugins/ArticyImporterForUnreal/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp:649:61: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
                #define OBJECT_WITH_X(x) TEXT(x), TEXT("IArticyObjectWith"x)
```

That are also fixed in this pull request.