### PR TITLE
Add support for MetaData on Arrays/Maps of ArticyRefs.

### DIFF
--- a/Source/ArticyEditor/Private/Customizations/ArticyRefCustomization.cpp
+++ b/Source/ArticyEditor/Private/Customizations/ArticyRefCustomization.cpp
@@ -163,7 +163,7 @@ UClass* FArticyRefCustomization::GetClassRestrictionMetaData() const
 
 	if(HasClassRestrictionMetaData())
 	{
-		const FString ArticyClassRestriction = ArticyRefPropertyHandle->GetProperty()->GetMetaData(TEXT("ArticyClassRestriction"));
+		const FString ArticyClassRestriction = ArticyRefPropertyHandle->GetMetaData(TEXT("ArticyClassRestriction"));
 
 		auto FullClassName = FString::Printf(TEXT("Class'/Script/%s.%s'"), TEXT("ArticyRuntime"), *ArticyClassRestriction);
 		Restriction = ConstructorHelpersInternal::FindOrLoadClass(FullClassName, UArticyObject::StaticClass());
@@ -181,7 +181,7 @@ UClass* FArticyRefCustomization::GetClassRestrictionMetaData() const
 
 bool FArticyRefCustomization::HasClassRestrictionMetaData() const
 {
-	return ArticyRefPropertyHandle->GetProperty()->HasMetaData(TEXT("ArticyClassRestriction"));
+	return ArticyRefPropertyHandle->HasMetaData(TEXT("ArticyClassRestriction"));
 }
 
 FArticyId FArticyRefCustomization::GetIdFromValueString(FString SourceString)


### PR DESCRIPTION
When using the GetMetaData and HasMetaData functions of the PropertyHandle instead of the Property it will use the metadata of the Array/Map instead, if this property is in an Array/Map.

```
UPROPERTY(EditAnywhere, BlueprintReadOnly, Meta=(ArticyClassRestriction="ArticyEntity"))
TArray<FArticyRef> Array;

UPROPERTY(EditAnywhere, BlueprintReadOnly, Meta=(ArticyClassRestriction="ArticyEntity"))
TMap<FName, FArticyRef> Map;
```