### PR TITLE
Hotfix for ArticyRef pin widgets being read-only

### DIFF
--- a/Source/ArticyEditor/Private/Slate/Pins/SArticyRefPin.cpp
+++ b/Source/ArticyEditor/Private/Slate/Pins/SArticyRefPin.cpp
@@ -21,7 +21,6 @@ TSharedRef<SWidget> SArticyRefPin::GetDefaultValueWidget()
 	return SNew(SArticyRefProperty)
 		.ArticyRefToDisplay(this, &SArticyRefPin::GetArticyRef)
 		.OnArticyRefChanged(this, &SArticyRefPin::OnArticyRefChanged)
-		.bIsReadOnly(true)
 		.Visibility(this, &SArticyRefPin::GetDefaultValueVisibility);
 }
 


### PR DESCRIPTION
Debug line of code that made ArticyRef pins read-only survived the testing process...