### PR TITLE
Fix ArticyInputPinsProvider Linker Error

### DIFF
--- a/Source/ArticyRuntime/Private/Interfaces/ArticyInputPinsProvider.cpp
+++ b/Source/ArticyRuntime/Private/Interfaces/ArticyInputPinsProvider.cpp
@@ -1,0 +1,47 @@
+//  
+// Copyright (c) articy Software GmbH & Co. KG. All rights reserved.  
+//
+
+#include "Interfaces/ArticyInputPinsProvider.h"
+
+/**
+* Tries to submerge into InputPins and explore there.
+* Returns false if no InputPins are found, or if none of them has connections.
+* NOTE: This method is only needed if an exploration starts at a flow node. Later (or if
+* it starts on a pin), exploration of pins will happen automatically as they are reached.
+*/
+bool IArticyInputPinsProvider::TrySubmerge(class UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth, const bool bForceShadowed)
+{
+	bool bSubmerged = false;
+
+	auto inPins = GetInputPins();
+	if(ensure(inPins) && inPins->Num() > 0)
+	{
+		//if there is more than one pin or the single pin has more connections,
+		//it must be a shadowed explore
+		const auto bShadowed = bForceShadowed
+                                || inPins->Num() > 1
+                                || ((*inPins)[0] && (*inPins)[0]->Connections.Num() > 1);
+
+		//submerge!
+		for(auto pin : *inPins)
+		{
+			//skip pins with no connections, since non-submergeable pins should not exist if
+			//at least one of the other pins can be submerged
+			//if none of the pins has connections, TrySubmerge will fail anyways, and the owner will be explored instead
+			if(ensure(pin) && pin->Connections.Num() > 0)
+			{
+				bSubmerged = true;
+				OutBranches.Append( Player->Explore(pin, bShadowed, Depth+1) );
+			}
+		}
+	}
+
+	return bSubmerged;
+}
+	
+const TArray<UArticyInputPin*>* IArticyInputPinsProvider::GetInputPins() const
+{
+	const static auto name = FName("InputPins");
+	return Cast<IArticyReflectable>(this)->GetPropPtr<TArray<UArticyInputPin*>>(name);
+}

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
@@ -9,13 +9,13 @@
 #include "ArticyInputPinsProvider.generated.h"
 
 UINTERFACE()
-class UArticyInputPinsProvider : public UArticyFlowObject { GENERATED_BODY() };
+class ARTICYRUNTIME_API UArticyInputPinsProvider : public UArticyFlowObject { GENERATED_BODY() };
 
 /**
  * All objects that have a property called 'InputPins' (which is an array of UArticyInputPin*)
  * implement this interface.
  */
-class IArticyInputPinsProvider : public IArticyFlowObject
+class ARTICYRUNTIME_API IArticyInputPinsProvider : public IArticyFlowObject
 {
 	GENERATED_BODY()
 
@@ -27,39 +27,7 @@ public:
 	 * NOTE: This method is only needed if an exploration starts at a flow node. Later (or if
 	 * it starts on a pin), exploration of pins will happen automatically as they are reached.
 	 */
-	bool TrySubmerge(class UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth, const bool bForceShadowed)
-	{
-		bool bSubmerged = false;
-
-		auto inPins = GetInputPins();
-		if(ensure(inPins) && inPins->Num() > 0)
-		{
-			//if there is more than one pin or the single pin has more connections,
-			//it must be a shadowed explore
-			const auto bShadowed = bForceShadowed
-									|| inPins->Num() > 1
-									|| ((*inPins)[0] && (*inPins)[0]->Connections.Num() > 1);
-
-			//submerge!
-			for(auto pin : *inPins)
-			{
-				//skip pins with no connections, since non-submergeable pins should not exist if
-				//at least one of the other pins can be submerged
-				//if none of the pins has connections, TrySubmerge will fail anyways, and the owner will be explored instead
-				if(ensure(pin) && pin->Connections.Num() > 0)
-				{
-					bSubmerged = true;
-					OutBranches.Append( Player->Explore(pin, bShadowed, Depth+1) );
-				}
-			}
-		}
-
-		return bSubmerged;
-	}
+	bool TrySubmerge(class UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth, const bool bForceShadowed);
 	
-	const TArray<UArticyInputPin*>* GetInputPins() const
-	{
-		const static auto name = FName("InputPins");
-		return Cast<IArticyReflectable>(this)->GetPropPtr<TArray<UArticyInputPin*>>(name);
-	}
+	const TArray<UArticyInputPin*>* GetInputPins() const;
 };


### PR DESCRIPTION
I'm trying to create my own `ArticyFlowPlayer`. Unfortunately when trying to access input pins, while the compilation passes, the build fails with a linker error.

```
void UQuestFlowPlayer::Play(UObject* const Node)
{
	TQueue<UObject*> NodesToProcess;
	NodesToProcess.Enqueue(Node);

	while (!NodesToProcess.IsEmpty())
	{
		auto CurrentNode = *NodesToProcess.Peek();
		NodesToProcess.Pop();

		auto result = this->OnPlayerPaused.Execute(CurrentNode);

		// If the listener said the execution shouldn't continue, the execution shouldn't
		// continue.
		if (!result)
		{
			continue;
		}

		if (static_cast<UObjectBase*>(CurrentNode)->GetClass()->IsChildOf(UArticyFlowFragment::StaticClass()))
		{
			auto FlowFragment = static_cast<UArticyFlowFragment*>(CurrentNode);
			auto ArticyInputPins = FlowFragment->GetInputPins(); // <== linker fails if this line is not commented
```

From what I could tell it's caused by the fact the implementation is not exported as API, and is defined in the header. So adding just the `ARTICYRUNTIME_API` isn't enough. The PR is just extracting the code in it's own CPP, so it can be exposed as a normal API.

For some reason the output pins are in their own CPP file, so no change is needed there.