### PR TITLE
Fix for Marking Database for Delete in Perforce

### DIFF
--- a/Source/ArticyEditor/Private/CodeGeneration/CodeGenerator.cpp
+++ b/Source/ArticyEditor/Private/CodeGeneration/CodeGenerator.cpp
@@ -292,13 +292,15 @@ void CodeGenerator::GenerateAssets(UArticyImportData* Data)
 		PackagesToSave.Add(AssetData.GetAsset()->GetOutermost());
 	}
 
-	// automatically save all articy assets
-	TArray<UPackage*> FailedToSavePackages;
-	FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false, &FailedToSavePackages);
+	// Check out all the assets we want to save
+	TArray<UPackage*> CheckedOutPackages;
+	FEditorFileUtils::CheckoutPackages(PackagesToSave, &CheckedOutPackages, false);
 
-	for (auto Package : FailedToSavePackages)
+	// Save the packages to disk
+	for (auto Package : PackagesToSave) { Package->SetDirtyFlag(true); }
+	if (!UEditorLoadingAndSavingUtils::SavePackages(PackagesToSave, true))
 	{
-		UE_LOG(LogArticyEditor, Error, TEXT("Could not save package %s"), *Package->GetName());
+		UE_LOG(LogArticyEditor, Error, TEXT("Failed to save packages. Make sure to save before submitting in Perforce."));
 	}
 
 	FArticyEditorModule::Get().OnAssetsGenerated.Broadcast();


### PR DESCRIPTION
This fixes a bug for Perforce users where triggering a rebuild of the generated Articy code would mark your package and database assets for "Delete" in Perforce despite the fact they'd been regenerated. They are now correctly checked out for edit instead.

Tested in Unreal 4.26. Builds in Unreal 5.