### PR TITLE
Improved Asserts when Deleting and Regenerating Assets

### DIFF
--- a/Source/ArticyEditor/Private/CodeGeneration/DatabaseGenerator.cpp
+++ b/Source/ArticyEditor/Private/CodeGeneration/DatabaseGenerator.cpp
@@ -61,5 +61,5 @@ void DatabaseGenerator::GenerateCode(const UArticyImportData* Data)
 UArticyDatabase* DatabaseGenerator::GenerateAsset(const UArticyImportData* Data)
 {
 	const auto className = CodeGenerator::GetDatabaseClassname(Data, true);
-	return ArticyImporterHelpers::GenerateAsset<UArticyDatabase>(*className, FApp::GetProjectName(), "", "", RF_ArchetypeObject);
+	return ArticyImporterHelpers::GenerateAsset<UArticyDatabase>(*className, FApp::GetProjectName(), "", "", RF_ArchetypeObject, true);
 }


### PR DESCRIPTION
In version `1.3.0` we fix a number of issues relating to source control plugins, especially the case where the plugin accidentally marks all the generated assets for `delete` when they should be marked as `edit`. 

Just in case these somehow reoccur despite the fix, I've added additional asserts which ensure that the old generated database is actually deleted before creating the new one and gently fail the import. Previously, this issue would crash the Unreal editor if any of your Articy objects changed templates between imports.