### PR TITLE
Allow setProp to be used on Reference Slots

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -49,6 +49,8 @@ struct ARTICYRUNTIME_API ExpressoType
 	virtual FString& GetString() { return StringValue; }
 	virtual const FString& GetString() const { return StringValue; }
 
+	virtual FString ToString() const;
+
 
 	//---------------------------------------------------------------------------//
 
@@ -328,7 +330,7 @@ protected:
 	 * Don't change the name, it's called like this in script fragments!
 	 */
 	template<typename ...ArgTypes>
-	static void print(const ExpressoType& Msg, ArgTypes... Args) { print(Msg.GetString(), Args...); }
+	static void print(const ExpressoType& Msg, ArgTypes... Args) { print(Msg.ToString(), Args...); }
 
 	/** Script conditions that are not empty, but rather contain something that evaluates to bool, return that condition. */
 	static const bool& ConditionOrTrue(const bool &Condition) { return Condition; }


### PR DESCRIPTION
Attempting to use `setProp` on a Reference Slot feature property with a value from `getObj` caused a crash. For ArticyId, it was expecting either an Int or Float type, but the result of getObj casts to a string.

I added support to parse this string and convert it into the appropriate 64-bit Articy Id value.

This also fixes a bug where non-string types could not be printed with the `print` Expresso method.