### PR TITLE
Don't Execute Paused Node Twice

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
+++ b/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
@@ -334,7 +334,7 @@ void UArticyFlowPlayer::UpdateAvailableBranches()
 
 //---------------------------------------------------------------------------//
 
-void UArticyFlowPlayer::UpdateAvailableBranchesInternal(bool IncludeCurrent)
+void UArticyFlowPlayer::UpdateAvailableBranchesInternal(bool Startup)
 {
 	AvailableBranches.Reset();
 
@@ -345,7 +345,7 @@ void UArticyFlowPlayer::UpdateAvailableBranchesInternal(bool IncludeCurrent)
 	else
 	{
 		const bool bMustBeShadowed = true;
-		AvailableBranches = Explore(&*Cursor, bMustBeShadowed, 0, IncludeCurrent);
+		AvailableBranches = Explore(&*Cursor, bMustBeShadowed, 0, Startup);
 
 		// Prune empty branches
 		AvailableBranches.RemoveAllSwap([](const FArticyBranch& branch) { return branch.Path.Num() == 0; });
@@ -354,8 +354,8 @@ void UArticyFlowPlayer::UpdateAvailableBranchesInternal(bool IncludeCurrent)
 		for (int32 i = 0; i < AvailableBranches.Num(); i++)
 			AvailableBranches[i].Index = i;
 
-		//if the cursor is at the StartOn node, check if we should fast-forward
-		if(Cursor.GetObject() == StartOn.GetObject(this) && FastForwardToPause())
+		// If we're just starting up, check if we should fast-forward
+		if(Startup && FastForwardToPause())
 		{
 			//fast-forwarding will call UpdateAvailableBranches again, can abort here
 			return;
@@ -420,7 +420,7 @@ bool UArticyFlowPlayer::FastForwardToPause()
 		}
 	}
 
-	if(ffwdIndex <= 0 || ffwdIndex >= firstPath.Num())
+	if(ffwdIndex < 0 || ffwdIndex >= firstPath.Num())
 	{
 		//no need to fast-forward
 		return false;

--- a/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -132,7 +132,7 @@ public:
 	 * The explore can be performed as shadowed operation.
 	 * If the node is submergeable, a submerge is performed.
 	 */
-	TArray<FArticyBranch> Explore(IArticyFlowObject* Node, bool bShadowed, int32 Depth);
+	TArray<FArticyBranch> Explore(IArticyFlowObject* Node, bool bShadowed, int32 Depth, bool IncludeCurrent = true);
 
 	void SetPauseOn(EArticyPausableType Types);
 	/** Returns true if Node is one of the PauseOn types. */
@@ -258,6 +258,15 @@ private:
 	mutable uint32 ShadowLevel = 0;
 
 private:
+	/**
+	 * Updates the list of available branches.
+	 * 
+	 * If IncludeCurrent is set, the branches will all begin with the current node.
+	 * This should only be done on startup when the cursor is reset. Otherwise, we'd
+	 * end up executing the current node twice (once upon playing a branch to it, once again when
+	 * playing a branch away from it). See https://github.com/ArticySoftware/ArticyImporterForUnreal/issues/50
+	 */
+	void UpdateAvailableBranchesInternal(bool IncludeCurrent);
 
 	/** The current position in the flow. */
 	UPROPERTY(Transient)

--- a/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -261,12 +261,10 @@ private:
 	/**
 	 * Updates the list of available branches.
 	 * 
-	 * If IncludeCurrent is set, the branches will all begin with the current node.
-	 * This should only be done on startup when the cursor is reset. Otherwise, we'd
-	 * end up executing the current node twice (once upon playing a branch to it, once again when
-	 * playing a branch away from it). See https://github.com/ArticySoftware/ArticyImporterForUnreal/issues/50
+	 * Use Startup if this is the first time we're creating branches for a starting node.
+	 * This will make sure FastForward gets called and we end up on a valid PauseOn node.
 	 */
-	void UpdateAvailableBranchesInternal(bool IncludeCurrent);
+	void UpdateAvailableBranchesInternal(bool Startup);
 
 	/** The current position in the flow. */
 	UPROPERTY(Transient)


### PR DESCRIPTION
We have a subtle bug where the present, paused on node is executed twice, once upon arrival, and once upon leaving.

This is caused by the logic in our `UpdateAvailableBranches` code. It always adds the current node to the start of every available branch. When advancing along a branch, we execute each node in the its path. Since the current node was previously the last node in the path of a branch, and is now the first node in the next branch, it's executed twice.

Normally, this was not a problem since only `OutputPin` and `Instruction` nodes have an implementation of `Execute` and usually `Instruction` nodes are not paused at. However, if the user does set `Instruction` in their Pause On setting on the flow player, they'll see this bug.

The original behavior of adding the present node to the start of each branch is maintained whenever we reset the current cursor, as we presumably want to make sure we execute the node we begin at.