### PR TITLE
Added Enum Hotreload Warning to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,3 +383,9 @@ These issues have been fixed in version `1.3.0` of the plugin. If you're still s
 Make sure you are exporting directly from Articy into your Unreal game directory. Alongside the `.articyue4` file there should be an `ArticyContent` directory with all your assets. 
 
 Both need to be copied into your Unreal project.
+
+## Hot Reloading Drop-Down List Changes
+
+Because of [a known issue with Unreal and hot-reloading changes to enums](https://issues.unrealengine.com/issue/UE-19528?lang=zh-CN), be very careful when hotreloading any changes to the values in a Drop-down list. If you save any Blueprint using the generated enum after hotreloading, you'll likely have all those nodes broken (converted into `bytes`) the next time you open the editor.
+
+When importing drop-down list changes, it's best to restart Unreal to avoid issues.


### PR DESCRIPTION
Unreal has a known issue with hot reloading changes to C++ enums. If you save any blueprint using the enum _after_ a hot reload, all affected nodes will be converted to bytes when you next reopen the editor. Generally this will require recreating any switches and resetting the value of any variables using the enum.

I've added a warning to the Readme under Common Issues to warn users that it's best to restart Unreal whenever importing changes to a drop-down list.