### PR TITLE
Support Blueprint Nativize

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -312,6 +312,9 @@ public:
 
 	void ChangePackageDefault(FName PackageName, bool bIsDefaultPackage);
 
+	UFUNCTION(BlueprintCallable, Category = "Articy")
+	void SetExpressoScriptsClass(TSubclassOf<UArticyExpressoScripts> NewClass);
+
 protected:
 
 	/** A list of all packages that were imported from articy:draft. */
@@ -327,9 +330,6 @@ protected:
 	TMap<FName, FArticyDatabaseObjectArray> LoadedObjectsByName;
 	
 	void UnloadAllPackages();
-
-	UFUNCTION(BlueprintCallable, Category="Articy")
-	void SetExpressoScriptsClass(TSubclassOf<UArticyExpressoScripts> NewClass);
 
 private:
 

--- a/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -235,17 +235,17 @@ public:
 			return *this = Value / Val.GetInt();
 	}
 
-protected:
-	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
-	int Value = -1;
-
 	/**
 	 * Set the value of this variable.
 	 * This internally calls the setter, so it guarantees that the correct shadow state is used (if any).
 	 */
-	UFUNCTION(BlueprintCallable, Category="ValueAccess")
+	UFUNCTION(BlueprintCallable, Category = "ValueAccess")
 	int Set(int NewValue) { return *this = NewValue; }
+
+protected:
+	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
+	int Value = -1;
 
 private:
 	TArray<ArticyShadowState<int>> Shadows;
@@ -273,17 +273,18 @@ public:
 		return Value = NewValue.GetBool();
 	}
 
-protected:
-	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
-	bool Value = false;
-
 	/**
 	 * Set the value of this variable.
 	 * This internally calls the setter, so it guarantees that the correct shadow state is used (if any).
 	 */
-	UFUNCTION(BlueprintCallable, Category="ValueAccess")
+	UFUNCTION(BlueprintCallable, Category = "ValueAccess")
 	bool Set(bool NewValue) { return *this = NewValue; }
+
+protected:
+
+	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
+	bool Value = false;
 
 private:
 	TArray<ArticyShadowState<bool>> Shadows;
@@ -321,17 +322,17 @@ public:
 	bool operator ==(const char* const text) const { return Value.Equals(text); }
 	bool operator !=(const char* const text) const { return !this->operator==(text); }
 
-protected:
-	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
-	FString Value;
-
 	/**
 	 * Set the value of this variable.
 	 * This internally calls the setter, so it guarantees that the correct shadow state is used (if any).
 	 */
-	UFUNCTION(BlueprintCallable, Category="ValueAccess")
+	UFUNCTION(BlueprintCallable, Category = "ValueAccess")
 	FString Set(FString NewValue) { return *this = NewValue; }
+
+protected:
+	/** The current value of this variable (i.e. the value of a shadow state, if any is active). */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Articy")
+	FString Value;
 
 private:
 	TArray<ArticyShadowState<FString>> Shadows;

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyReflectable.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyReflectable.h
@@ -77,7 +77,7 @@ public:
 		return GetPropertyPointers(Class).Find(Property) != nullptr;
 	}
 
-	virtual UClass* GetClass() const { return _getUObject()->GetClass(); }
+	virtual UClass* GetObjectClass() const { return _getUObject()->GetClass(); }
 
 private:
 	/**
@@ -87,7 +87,7 @@ private:
 	 */
 	TMap<FName, UProperty*>& GetPropertyPointers() const
 	{
-		return GetPropertyPointers(GetClass());
+		return GetPropertyPointers(GetObjectClass());
 	}
 
 	static TMap<FName, UProperty*>& GetPropertyPointers(const UClass* Class)


### PR DESCRIPTION
Previously, the plugin generated non-compilable C++ code when using Blueprint Nativize. There were two culprits.

1. A method on `IArticyReflectable` which shared its name `GetClass` with a method on `UObject`, creating an ambiguous call.
2. A number of `BlueprintCallable` methods which were `protected`, not `public`, creating compile errors (it seems protected variables are fine though, as nativize builds a workaround).

There may be more issues, but I haven't identified any more in testing.