### PR TITLE
Add Support for Matrix Property

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyBuiltinTypes.cpp
+++ b/Source/ArticyRuntime/Private/ArticyBuiltinTypes.cpp
@@ -146,5 +146,11 @@ void UArticyTransformation::InitFromJson(TSharedPtr<FJsonValue> Json)
 			Translation = ArticyHelpers::ParseFVector2DFromJson(translationJson);
 	}
 
+	{
+		auto matrixJson = obj->TryGetField(STRINGIFY(Matrix));
+		if (matrixJson.IsValid())
+			Matrix = ArticyHelpers::ParseFMatrixFromJson(matrixJson);
+	}
+
 	JSON_TRY_FLOAT(obj, Rotation);
 }

--- a/Source/ArticyRuntime/Public/ArticyBuiltinTypes.h
+++ b/Source/ArticyRuntime/Public/ArticyBuiltinTypes.h
@@ -143,6 +143,8 @@ public:
 	float Rotation;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Articy")
 	FVector2D Translation;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Articy")
+	FMatrix Matrix;
 
 private:
 	template<typename Type, typename PropType>

--- a/Source/ArticyRuntime/Public/ArticyHelpers.h
+++ b/Source/ArticyRuntime/Public/ArticyHelpers.h
@@ -117,6 +117,29 @@ namespace ArticyHelpers
 		return FVector2D{ static_cast<float>(X), static_cast<float>(Y) };
 	}
 
+	inline FMatrix ParseFMatrixFromJson(const TSharedPtr<FJsonValue> Json)
+	{
+		if (!Json.IsValid() || !ensure(Json->Type == EJson::Array))
+			return FMatrix::Identity;
+
+		auto JsonArray = Json->AsArray();
+		if (!ensure(JsonArray.Num() == 9))
+			return FMatrix::Identity;
+
+		TArray< float > FloatArray = TArray<float>();
+		for (auto& JsonFloatValue : JsonArray)
+		{
+			FloatArray.Add(static_cast<float>(JsonFloatValue->AsNumber()));
+		}
+
+		return FMatrix{
+			FPlane{FloatArray[0], FloatArray[1], FloatArray[2], 0.f},
+			FPlane{FloatArray[3], FloatArray[4], FloatArray[5], 0.f},
+			FPlane{0.f, 0.f, FloatArray[8], 0.f},
+			FPlane{FloatArray[6], FloatArray[7], 0.f, 1.f},
+		};
+	}
+
 	inline FLinearColor ParseColorFromJson(const TSharedPtr<FJsonValue> Json)
 	{
 		if(!Json.IsValid() || !ensure(Json->Type == EJson::Object))

--- a/Source/ArticyRuntime/Public/ArticyHelpers.h
+++ b/Source/ArticyRuntime/Public/ArticyHelpers.h
@@ -132,10 +132,12 @@ namespace ArticyHelpers
 			FloatArray.Add(static_cast<float>(JsonFloatValue->AsNumber()));
 		}
 
+		// Take the 2D 3x3 Matrix from Articy:draft and conver it to a 3D 4x4 Matrix for Unreal
 		return FMatrix{
 			FPlane{FloatArray[0], FloatArray[1], FloatArray[2], 0.f},
 			FPlane{FloatArray[3], FloatArray[4], FloatArray[5], 0.f},
 			FPlane{0.f, 0.f, FloatArray[8], 0.f},
+			// Translation values need to be moved over as they're always on the last column of the matrix
 			FPlane{FloatArray[6], FloatArray[7], 0.f, 1.f},
 		};
 	}


### PR DESCRIPTION
Adding support for the new Matrix property in Articy:draft's JSON export. This property combines the translation, rotation, and scale of location objects like Zones, Text, and Images.

The 3x3 2D JSON matrix is converted into a 4x4 Unreal FMatrix that can operate on 2D and 3D vectors alike.