### PR TITLE
Make it easier to depend on ArticyEditorModule

### DIFF
--- a/Source/ArticyEditor/ArticyEditor.Build.cs
+++ b/Source/ArticyEditor/ArticyEditor.Build.cs
@@ -30,6 +30,8 @@ public class ArticyEditor : ModuleRules
 			new string[]
 			{
 				"Core",
+				"ArticyRuntime",
+				"EditorWidgets",
 				//"ClassViewer"
 				// ... add other public dependencies that you statically link with here ...
 			}
@@ -48,13 +50,11 @@ public class ArticyEditor : ModuleRules
 				"Slate",
 				"SlateCore",
 				// ... add private dependencies that you statically link with here ...	
-                "ArticyRuntime",
 				"Json",
                 "GameProjectGeneration",
                 "ContentBrowser",
 				"PropertyEditor",
 				"EditorStyle",
-				"EditorWidgets",
 				"SourceControl",
 				"GraphEditor",
 				"ApplicationCore",


### PR DESCRIPTION
There were a number of dependencies of ArticyEditorModule set to private which really ought to be public. Attempting to depend on ArticyEditorModule (such as if, for example, you wanted to add custom hooks to the importer) would generate errors as a result unless you manually added these dependencies to your own module's list.