### PR TITLE
Allow GetInputPins from Blueprint

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
+++ b/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
@@ -188,7 +188,7 @@ IArticyFlowObject* UArticyFlowPlayer::GetUnshadowedNode(IArticyFlowObject* Node)
 
 		TArray<UArticyFlowPin*> pins;
 		auto inputPinsOwner = Cast<IArticyInputPinsProvider>(pinOwner);
-		pins.Append(*inputPinsOwner->GetInputPins());
+		pins.Append(*inputPinsOwner->GetInputPinsPtr());
 		auto outputPinsOwner = Cast<IArticyOutputPinsProvider>(pinOwner);
 		pins.Append(*outputPinsOwner->GetOutputPinsPtr());
 

--- a/Source/ArticyRuntime/Private/Interfaces/ArticyInputPinsProvider.cpp
+++ b/Source/ArticyRuntime/Private/Interfaces/ArticyInputPinsProvider.cpp
@@ -14,7 +14,7 @@ bool IArticyInputPinsProvider::TrySubmerge(class UArticyFlowPlayer* Player, TArr
 {
 	bool bSubmerged = false;
 
-	auto inPins = GetInputPins();
+	auto inPins = GetInputPinsPtr();
 	if(ensure(inPins) && inPins->Num() > 0)
 	{
 		//if there is more than one pin or the single pin has more connections,
@@ -40,8 +40,17 @@ bool IArticyInputPinsProvider::TrySubmerge(class UArticyFlowPlayer* Player, TArr
 	return bSubmerged;
 }
 	
-const TArray<UArticyInputPin*>* IArticyInputPinsProvider::GetInputPins() const
+const TArray<UArticyInputPin*>* IArticyInputPinsProvider::GetInputPinsPtr() const
 {
 	const static auto name = FName("InputPins");
 	return Cast<IArticyReflectable>(this)->GetPropPtr<TArray<UArticyInputPin*>>(name);
+}
+
+TArray<UArticyInputPin*> IArticyInputPinsProvider::GetInputPins_Implementation() const
+{
+	auto Pins = GetInputPinsPtr();
+	if (Pins)
+		return *Pins;
+	else
+		return TArray<UArticyInputPin*>();
 }

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
@@ -28,6 +28,11 @@ public:
 	 * it starts on a pin), exploration of pins will happen automatically as they are reached.
 	 */
 	bool TrySubmerge(class UArticyFlowPlayer* Player, TArray<FArticyBranch>& OutBranches, const uint32& Depth, const bool bForceShadowed);
-	
-	const TArray<UArticyInputPin*>* GetInputPins() const;
+
+	const TArray<UArticyInputPin*>* GetInputPinsPtr() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Articy")
+	TArray<UArticyInputPin*> GetInputPins() const;
+
+	TArray<UArticyInputPin*> GetInputPins_Implementation() const;
 };


### PR DESCRIPTION
Allows users to call GetInputPins on an Input Pin Provider (like Dialogue Fragments, Dialogues, etc.) from Blueprint.

This involves one breaking change: the native `GetInputPins()` now returns an array by value, not as a pointer. If you were using `GetInputPins` from C++, you'll need to switch all usages to `GetInputPinsPtr`.