### PR TITLE
PS5 Build Fix

### DIFF
--- a/Source/ArticyEditor/Private/CodeGeneration/ExpressoScriptsGenerator.cpp
+++ b/Source/ArticyEditor/Private/CodeGeneration/ExpressoScriptsGenerator.cpp
@@ -124,8 +124,10 @@ void GenerateExpressoScripts(CodeFileGenerator* header, const UArticyImportData*
 	header->Line();
 	// disable "optimization cannot be applied due to function size" compile error. This error is caused by the huge constructor when all expresso
 	// scripts are added to the collection and this pragma disables the optimizations. 
+#if !((defined(PLATFORM_PS4) && PLATFORM_PS4) || (defined(PLATFORM_PS5) && PLATFORM_PS5))
 	header->Line("#pragma warning(push)");
 	header->Line("#pragma warning(disable: 4883) //<disable \"optimization cannot be applied due to function size\" compile error.");
+#endif
 	header->Method("", CodeGenerator::GetExpressoScriptsClassname(Data), "", [&]
 	{
 		const auto fragments = Data->GetScriptFragments();
@@ -164,7 +166,9 @@ void GenerateExpressoScripts(CodeFileGenerator* header, const UArticyImportData*
 			}
 		}
 	});
+#if !((defined(PLATFORM_PS4) && PLATFORM_PS4) || (defined(PLATFORM_PS5) && PLATFORM_PS5))
 	header->Line("#pragma warning(pop)");
+#endif
 }
 
 void ExpressoScriptsGenerator::GenerateCode(const UArticyImportData* Data)

--- a/Source/ArticyEditor/Private/CodeGeneration/GlobalVarsGenerator.cpp
+++ b/Source/ArticyEditor/Private/CodeGeneration/GlobalVarsGenerator.cpp
@@ -25,8 +25,10 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 
 		// disable "optimization cannot be applied due to function size" compile error. This error is caused by the huge constructor when all expresso
 		// scripts are added to the collection and this pragma disables the optimizations.
+#if !((defined(PLATFORM_PS4) && PLATFORM_PS4) || (defined(PLATFORM_PS5) && PLATFORM_PS5))
 		header->Line("#pragma warning(push)");
 		header->Line("#pragma warning(disable: 4883) //<disable \"optimization cannot be applied due to function size\" compile error.");
+#endif
 		
 		//generate all the namespaces (with comment)
 		for(const auto ns : Data->GetGlobalVars().Namespaces)
@@ -118,7 +120,9 @@ void GlobalVarsGenerator::GenerateCode(const UArticyImportData* Data)
 				TEXT("BlueprintPure, Category=\"ArticyGlobalVariables\", meta=(HidePin=\"WorldContext\", DefaultToSelf=\"WorldContext\", DisplayName=\"GetArticyGV\", keywords=\"global variables\")"));
 		});
 
+#if !((defined(PLATFORM_PS4) && PLATFORM_PS4) || (defined(PLATFORM_PS5) && PLATFORM_PS5))
 		header->Line("#pragma warning(pop)");
+#endif
 	});
 }
 


### PR DESCRIPTION
Fixes build errors on PS5.

The main issue was that we were emitting `#pragma warning`s that aren't supported by the CLang compiler used by PS4/5. The warning we were disabling is specific to Microsoft so it shouldn't be an issue we're not emitting these pragmas on these platforms.