### PR TITLE
Fix FADIHierarchy::RootObject Package Warning

### DIFF
--- a/Source/ArticyEditor/Public/ArticyImportData.h
+++ b/Source/ArticyEditor/Public/ArticyImportData.h
@@ -250,7 +250,7 @@ struct FADIHierarchy
 
 public:
 	UPROPERTY(VisibleAnywhere, Category="Hierarchy")
-	UADIHierarchyObject* RootObject;
+	UADIHierarchyObject* RootObject = nullptr;
 
 	void ImportFromJson(UArticyImportData* ImportData, const TSharedPtr<FJsonObject> JsonRoot);
 };


### PR DESCRIPTION
Minor packaging warning because the `RootObject` pointer wasn't initialized to `nullptr` in `FADIHierarchy`.