### PR TITLE
remove win32 from the whitelist platforms list

### DIFF
--- a/ArticyImporter.uplugin
+++ b/ArticyImporter.uplugin
@@ -20,7 +20,6 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win32",
 				"Win64",
 				"Mac",
 				"IOS",
@@ -32,7 +31,6 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win32",
 				"Win64",
 				"Mac",
 				"IOS",


### PR DESCRIPTION
Fix for compile warning. Win32 is no longer supported.