### PR TITLE
Fixed EArticyPausableType bit flags to be used correctly

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
+++ b/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
@@ -105,7 +105,7 @@ void UArticyFlowPlayer::FinishCurrentPausedObject(int PinIndex)
 
 bool UArticyFlowPlayer::ShouldPauseOn(IArticyFlowObject* Node) const
 {
-	return Node && (1 << static_cast<uint8>(Node->GetType()) & PauseOn);
+	return Node && (static_cast<uint8>(Node->GetType()) & PauseOn);
 }
 
 bool UArticyFlowPlayer::ShouldPauseOn(TScriptInterface<IArticyFlowObject> Node) const
@@ -314,18 +314,6 @@ TArray<FArticyBranch> UArticyFlowPlayer::Explore(IArticyFlowObject* Node, bool b
 	}
 
 	return OutBranches;
-}
-
-void UArticyFlowPlayer::SetPauseOn(EArticyPausableType Types)
-{
-	PauseOn = 1 << uint8(Types & EArticyPausableType::DialogueFragment)
-		| 1 << uint8(Types & EArticyPausableType::Dialogue)
-		| 1 << uint8(Types & EArticyPausableType::FlowFragment)
-		| 1 << uint8(Types & EArticyPausableType::Hub)
-		| 1 << uint8(Types & EArticyPausableType::Jump)
-		| 1 << uint8(Types & EArticyPausableType::Condition)
-		| 1 << uint8(Types & EArticyPausableType::Instruction)
-		| 1 << uint8(Types & EArticyPausableType::Pin);
 }
 
 //---------------------------------------------------------------------------//

--- a/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
+++ b/Source/ArticyRuntime/Public/ArticyFlowPlayer.h
@@ -13,17 +13,18 @@
 
 class IArticyNode;
 class IArticyFlowObject;
-UENUM(BlueprintType, meta = (Bitflags))
+UENUM(BlueprintType, meta = (Bitflags, UseEnumValuesAsMaskValuesInEditor = "true"))
 enum class EArticyPausableType : uint8
 {
-	FlowFragment,
-	Dialogue,
-	DialogueFragment,
-	Hub,
-	Jump,
-	Condition,
-	Instruction,
-	Pin
+	None                = 0 UMETA(Hidden),
+	FlowFragment        = 1 << 0,
+	Dialogue            = 1 << 1,
+	DialogueFragment    = 1 << 2,
+	Hub                 = 1 << 3,
+	Jump                = 1 << 4,
+	Condition           = 1 << 5,
+	Instruction         = 1 << 6,
+	Pin                 = 1 << 7,
 };
 ENUM_CLASS_FLAGS(EArticyPausableType);
 
@@ -67,11 +68,11 @@ public:
 
 	//---------------------------------------------------------------------------//
 
-	//EArticyPausableType
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Setup", meta=(Bitmask, BitmaskEnum = "/Script/ArticyRuntime.EArticyPausableType"))
-	uint8 PauseOn = 1 << uint8(EArticyPausableType::DialogueFragment)
-					| 1 << uint8(EArticyPausableType::Dialogue)
-					| 1 << uint8(EArticyPausableType::FlowFragment);
+	// Indicates which pausable types should be paused on
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Setup", meta=(Bitmask, BitmaskEnum = EArticyPausableType))
+	uint8 PauseOn = uint8(EArticyPausableType::FlowFragment)
+					| uint8(EArticyPausableType::Dialogue)
+					| uint8(EArticyPausableType::DialogueFragment);
 
 	/**
 	 * Pushes a shadow state, executes the operation, then pops the shadow state back.
@@ -135,7 +136,6 @@ public:
 	 */
 	TArray<FArticyBranch> Explore(IArticyFlowObject* Node, bool bShadowed, int32 Depth, bool IncludeCurrent = true);
 
-	void SetPauseOn(EArticyPausableType Types);
 	/** Returns true if Node is one of the PauseOn types. */
 	bool ShouldPauseOn(IArticyFlowObject* Node) const;
 


### PR DESCRIPTION
- The EArticyPausableType was not set up correctly, causing pause events to happen when they shouldn't. Changed the enum to use proper bit flags which fixed the issue. 
- Removed the SetPauseOn function since it is no longer needed as you can set the public PauseOn variable directly (it also had the enum entries in the wrong order)