### PR TITLE
Fix compile error in generated code when returning 'object' from an articy script method.

### DIFF
--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -206,10 +206,10 @@ const FString& FAIDScriptMethod::GetCPPDefaultReturn() const
 		const static auto EmptyString = FString{"\"\""};
 		return EmptyString;
 	}
-	if (ReturnType == "ArticyObject")
+	if (ReturnType == "object")
 	{
-		const static auto ArticyObject = FString{"nullptr"};
-		return ArticyObject;
+		const static auto NullPtr = FString{"nullptr"};
+		return NullPtr;
 	}
 
 	const static auto Nothing = FString{""};


### PR DESCRIPTION
In an Articy instruction block, if something like the following is entered:
```
MyVariableSet.MyBooleanVariable = getPrimaryCharacter() == speaker;
```
On importing to UE, the C++ generator will generate methods which won't compile. Something along the lines of:
```
UArticyPrimitive* getPrimaryCharacter() {}
```
The body should `return nullptr;` within the function's braces.

The previous code was effectively checking the JSON file's exported return type for a value that doesn't appear to be possible. I've adjusted the check to match the above function `GetCPPReturnType()`.